### PR TITLE
since ignore is set namespace creation works

### DIFF
--- a/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
@@ -230,12 +230,13 @@ var _ = Describe("", func() {
 			}, defaultTimeoutSeconds*6, 1).Should(ContainSubstring("namespace/e2etestsuccess created"))
 		})
 		It("Creating an invalid ns should generate a violation message", func() {
+			// Due to the ignore flag being set, namespace creation will work, but the violation is still created
 			By("Creating invalid namespace on managed")
 			Eventually(func() interface{} {
 				out, _ := exec.Command("kubectl", "create", "ns", "e2etestfail", "--kubeconfig="+kubeconfigManaged).CombinedOutput()
 				fmt.Println(string(out))
 				return string(out)
-			}, defaultTimeoutSeconds*2, 1).Should(ContainSubstring("denied by ns-must-have-gk"))
+			}, defaultTimeoutSeconds*2, 1).Should(ContainSubstring("namespace/e2etestfail created"))
 			By("Checking if status for policy template policy-gatekeeper-admission is noncompliant")
 			Eventually(func() interface{} {
 				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)


### PR DESCRIPTION
Canary failure in issue https://github.com/open-cluster-management/backlog/issues/10253 I think happened
because now we set an ignore flag to ignore gatekeeper violations.  So in this case the namespace still gets
created, but the audit entry is still logged.

May want @ycao56 to decide if this is the way we want to keep this test.