### PR TITLE
Disable standalone UI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ jobs:
         - COMPONENT_E2E_TEST_COMMAND=${TRAVIS_BUILD_DIR}/build/run-e2e-tests-ui.sh
       script: 
         - |
+          export CYPRESS_STANDALONE_TESTSUITE_EXECUTION="FALSE"
           make
           make component/test/e2e
       after_failure:
@@ -78,7 +79,7 @@ jobs:
           make
           make component/test/e2e
     - stage: test-e2e
-      name: "Test polices from policy-collection repo"
+      name: "Test policies from policy-collection repo"
       if: type != pull_request AND branch = main
       env:
         - COMPONENT_E2E_TEST_COMMAND=${TRAVIS_BUILD_DIR}/build/run-e2e-tests-policy-framework.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,8 +89,6 @@ jobs:
           export COMPONENT_NAME="grc-policy-framework-tests"
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export COMPONENT_TAG_EXTENSION="-PR${TRAVIS_PULL_REQUEST}-${TRAVIS_COMMIT}"; fi;
           make component/pull
-          echo "Wait for UI to check empty resource page"
-          sleep 6m
           make component/test/e2e
     - stage: ff
       name: "Fast forwarding GRC repos"

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -49,12 +49,6 @@ make kind-deploy-policy-controllers
 
 kubectl get pods -A
 
-# Allow UI tests to continue to check empty resource page
-if [[ "${TRAVIS_EVENT_TYPE}" != "pull_request" ]]; then
-    echo "Waiting for UI E2E to check empty resource page"
-    sleep 6m
-fi
-
 echo "all ready! start to test"
 
 make e2e-test


### PR DESCRIPTION
Due to E2E test concurrency, we've implemented a `CYPRESS_STANDALONE_TESTSUITE_EXECUTION` flag so that the UI E2E tests loosen its checks due to the extra policies that are present from the other E2E tests.

GRC UI PR: https://github.com/open-cluster-management/grc-ui/pull/498