### PR TITLE
Move standalone var to Docker call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ jobs:
         - COMPONENT_E2E_TEST_COMMAND=${TRAVIS_BUILD_DIR}/build/run-e2e-tests-ui.sh
       script: 
         - |
-          export CYPRESS_STANDALONE_TESTSUITE_EXECUTION="FALSE"
           make
           make component/test/e2e
       after_failure:

--- a/build/run-e2e-tests-ui.sh
+++ b/build/run-e2e-tests-ui.sh
@@ -45,5 +45,6 @@ docker run --volume $(pwd)/results:/opt/app-root/src/grc-ui/test-output/e2e \
     --env RBAC_PASS=$RBAC_PASS \
     --env PAUSE=0 \
     --env FAIL_FAST=true \
+    --env STANDALONE_TESTSUITE_EXECUTION=false \
     --env MANAGED_CLUSTER_NAME=$MANAGED_CLUSTER_NAME \
     $DOCKER_URI


### PR DESCRIPTION
Implement `STANDALONE_TESTSUITE_EXECUTION` properly (reverts https://github.com/open-cluster-management/governance-policy-framework/pull/78)

(See related PR https://github.com/open-cluster-management/grc-ui/pull/502)