### PR TITLE
increase timeout for gatekeeper pod to be running

### DIFF
--- a/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
@@ -107,7 +107,7 @@ var _ = Describe("", func() {
 					}
 				}
 				return "nil"
-			}, defaultTimeoutSeconds*2, 1).Should(Equal("Running"))
+			}, defaultTimeoutSeconds*4, 1).Should(Equal("Running"))
 		})
 		// set to ignore to ensure it won't fail other tests running in parallel
 		It("Patching webhook check-ignore-label.gatekeeper.sh failurePolicy to ignore", func() {

--- a/test/policy-collection/policy_gatekeeper_operator_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_test.go
@@ -155,7 +155,7 @@ var _ = Describe("", func() {
 					}
 				}
 				return "nil"
-			}, defaultTimeoutSeconds*2, 1).Should(Equal("Running"))
+			}, defaultTimeoutSeconds*4, 1).Should(Equal("Running"))
 		})
 		// set to ignore to ensure it won't fail other tests running in parallel
 		It("Patching webhook check-ignore-label.gatekeeper.sh failurePolicy to ignore", func() {


### PR DESCRIPTION
I think this would be the proposed change to address the failing canary.  https://github.com/open-cluster-management/backlog/issues/10545

@ycao56 What do you think about the canary failure and whether you think this will help?