### PR TITLE
remove error check inside eventually() for ComplianceCheckResult

### DIFF
--- a/test/policy-collection/policy_comp_operator_test.go
+++ b/test/policy-collection/policy_comp_operator_test.go
@@ -303,8 +303,7 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] Test compliance opera
 		It("ComplianceCheckResult should be created", func() {
 			By("Checking if any ComplianceCheckResult CR exists on managed cluster")
 			Eventually(func() interface{} {
-				list, err := clientManagedDynamic.Resource(gvrComplianceCheckResult).Namespace("openshift-compliance").List(context.TODO(), metav1.ListOptions{})
-				Expect(err).To(BeNil())
+				list, _ := clientManagedDynamic.Resource(gvrComplianceCheckResult).Namespace("openshift-compliance").List(context.TODO(), metav1.ListOptions{})
 				return len(list.Items)
 			}, defaultTimeoutSeconds*8, 1).ShouldNot(Equal(0))
 		})


### PR DESCRIPTION
for https://github.com/open-cluster-management/backlog/issues/12138

avoid checking for error inside this eventually() block to allow the test to retry after a failure