### PR TITLE
Move community operator to unrestricted namespace

### DIFF
--- a/test/policy-collection/policy_gatekeeper_operator_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_test.go
@@ -45,8 +45,8 @@ var _ = Describe("", func() {
 	const GKAssignMetadataPolicyName = "policy-gatekeeper-annotation-owner"
 	Describe("RHACM4K-1692 GRC: [P1][Sev1][policy-grc] Test installing gatekeeper operator", func() {
 		It("Clean up before all", func() {
-			By("checking if openshift-gatekeeper-operator ns exists")
-			_, err := clientManaged.CoreV1().Namespaces().Get(context.TODO(), "openshift-gatekeeper-operator", metav1.GetOptions{})
+			By("checking if gatekeeper-operator ns exists")
+			_, err := clientManaged.CoreV1().Namespaces().Get(context.TODO(), "gatekeeper-operator", metav1.GetOptions{})
 			if err == nil || !errors.IsNotFound(err) {
 				utils.KubectlWithOutput("delete", "-f", GKAssignMetadataPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
 				Eventually(func() interface{} {
@@ -66,18 +66,18 @@ var _ = Describe("", func() {
 				}, defaultTimeoutSeconds, 1).Should(BeNil())
 				utils.KubectlWithOutput("delete", "ns", "e2etestsuccess", "--kubeconfig="+kubeconfigManaged)
 				utils.KubectlWithOutput("delete", "ns", "e2etestfail", "--kubeconfig="+kubeconfigManaged)
-				By("namespace openshift-gatekeeper-operator exists, cleaning up...")
+				By("namespace gatekeeper-operator exists, cleaning up...")
 				utils.KubectlWithOutput("delete", "-f", gatekeeperPolicyURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
 				Eventually(func() interface{} {
 					managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
 					return managedPlc
 				}, defaultTimeoutSeconds, 1).Should(BeNil())
-				utils.KubectlWithOutput("delete", "-n", "openshift-gatekeeper-operator", "Gatekeeper", "gatekeeper", "--kubeconfig="+kubeconfigManaged)
-				utils.KubectlWithOutput("delete", "-n", "openshift-gatekeeper-operator", "subscriptions.operators.coreos.com", "gatekeeper-operator-sub", "--kubeconfig="+kubeconfigManaged)
-				utils.KubectlWithOutput("delete", "-n", "openshift-gatekeeper-operator", "OperatorGroup", "gatekeeper-operator", "--kubeconfig="+kubeconfigManaged)
+				utils.KubectlWithOutput("delete", "-n", "gatekeeper-operator", "Gatekeeper", "gatekeeper", "--kubeconfig="+kubeconfigManaged)
+				utils.KubectlWithOutput("delete", "-n", "gatekeeper-operator", "subscriptions.operators.coreos.com", "gatekeeper-operator-sub", "--kubeconfig="+kubeconfigManaged)
+				utils.KubectlWithOutput("delete", "-n", "gatekeeper-operator", "OperatorGroup", "gatekeeper-operator", "--kubeconfig="+kubeconfigManaged)
 				utils.KubectlWithOutput("delete", "crd", "gatekeepers.operator.gatekeeper.sh", "--kubeconfig="+kubeconfigManaged)
-				out, _ := utils.KubectlWithOutput("delete", "ns", "openshift-gatekeeper-operator", "--kubeconfig="+kubeconfigManaged)
-				Expect(out).To(ContainSubstring("namespace \"openshift-gatekeeper-operator\" deleted"))
+				out, _ := utils.KubectlWithOutput("delete", "ns", "gatekeeper-operator", "--kubeconfig="+kubeconfigManaged)
+				Expect(out).To(ContainSubstring("namespace \"gatekeeper-operator\" deleted"))
 			}
 		})
 		It("community/policy-gatekeeper-operator should be created on hub", func() {
@@ -133,13 +133,13 @@ var _ = Describe("", func() {
 		It("Gatekeeper operator pod should be running", func() {
 			By("Checking if pod gatekeeper-operator has been created")
 			Eventually(func() interface{} {
-				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-operator").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=controller-manager"})
+				podList, err := clientManaged.CoreV1().Pods("gatekeeper-operator").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=controller-manager"})
 				Expect(err).To(BeNil())
 				return len(podList.Items)
 			}, defaultTimeoutSeconds*8, 1).ShouldNot(Equal(0))
 			By("Checking if pod gatekeeper-operator is running")
 			Eventually(func() interface{} {
-				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-operator").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=controller-manager"})
+				podList, err := clientManaged.CoreV1().Pods("gatekeeper-operator").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=controller-manager"})
 				Expect(err).To(BeNil())
 				for _, item := range podList.Items {
 					if strings.HasPrefix(item.ObjectMeta.Name, "gatekeeper-operator-controller-manager") {
@@ -544,11 +544,11 @@ var _ = Describe("", func() {
 				out, _ := utils.KubectlWithOutput("get", "ns", "openshift-gatekeeper-system", "--kubeconfig="+kubeconfigManaged)
 				return out
 			}, defaultTimeoutSeconds*4, 1).Should(ContainSubstring("namespaces \"openshift-gatekeeper-system\" not found"))
-			utils.KubectlWithOutput("delete", "-n", "openshift-gatekeeper-operator", "subscriptions.operators.coreos.com", "gatekeeper-operator-sub", "--kubeconfig="+kubeconfigManaged)
-			utils.KubectlWithOutput("delete", "-n", "openshift-gatekeeper-operator", "OperatorGroup", "gatekeeper-operator", "--kubeconfig="+kubeconfigManaged)
+			utils.KubectlWithOutput("delete", "-n", "gatekeeper-operator", "subscriptions.operators.coreos.com", "gatekeeper-operator-sub", "--kubeconfig="+kubeconfigManaged)
+			utils.KubectlWithOutput("delete", "-n", "gatekeeper-operator", "OperatorGroup", "gatekeeper-operator", "--kubeconfig="+kubeconfigManaged)
 			utils.KubectlWithOutput("delete", "crd", "gatekeepers.operator.gatekeeper.sh", "--kubeconfig="+kubeconfigManaged)
-			out, _ := utils.KubectlWithOutput("delete", "ns", "openshift-gatekeeper-operator", "--kubeconfig="+kubeconfigManaged)
-			Expect(out).To(ContainSubstring("namespace \"openshift-gatekeeper-operator\" deleted"))
+			out, _ := utils.KubectlWithOutput("delete", "ns", "gatekeeper-operator", "--kubeconfig="+kubeconfigManaged)
+			Expect(out).To(ContainSubstring("namespace \"gatekeeper-operator\" deleted"))
 			utils.KubectlWithOutput("delete", "events", "-n", clusterNamespace, "--field-selector=involvedObject.name="+userNamespace+".policy-gatekeeper-operator", "--kubeconfig="+kubeconfigManaged)
 			utils.KubectlWithOutput("delete", "events", "-n", clusterNamespace, "--field-selector=involvedObject.name="+userNamespace+".policy-gatekeeper", "--kubeconfig="+kubeconfigManaged)
 			utils.KubectlWithOutput("delete", "events", "-n", clusterNamespace, "--field-selector=involvedObject.name="+userNamespace+".policy-gatekeeper-image-pull-policy", "--kubeconfig="+kubeconfigManaged)


### PR DESCRIPTION
To match the (pending) PR changing where the community gatekeeper
operator is installed, because `openshift-*` namespaces might be
restricted in some OpenShift clusters.

Refs:
 - https://github.com/open-cluster-management/policy-collection/pull/125
 - https://github.com/open-cluster-management/backlog/issues/13759

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>