### PR TITLE
Add case to not skip gatekeeper tests

### DIFF
--- a/test/policy-collection/policy_comp_operator_test.go
+++ b/test/policy-collection/policy_comp_operator_test.go
@@ -46,6 +46,10 @@ func canCreateOpenshiftNamespaces() bool {
 		// Weird situation, but probably means it could make the namespace
 		return true
 	}
+	if strings.Contains(out, "admission webhook \"mutation.gatekeeper.sh\" does not support dry run") {
+		// Gatekeeper is installed, so assume the namespace could be created
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
The sample gatekeeper policy created during the tests makes an admission
webhook that prevents the server-side dry-run from testing whether an
openshift-* namespace can be created. But if gatekeeper (and this rule)
are already present, then we can assume we would be able to make the ns.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/13759

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>