### PR TITLE
check for an error instead of ignoring it

### DIFF
--- a/test/policy-collection/policy_comp_operator_test.go
+++ b/test/policy-collection/policy_comp_operator_test.go
@@ -338,7 +338,8 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] Test compliance opera
 		It("ComplianceCheckResult should be created", func() {
 			By("Checking if any ComplianceCheckResult CR exists on managed cluster")
 			Eventually(func() interface{} {
-				list, _ := clientManagedDynamic.Resource(gvrComplianceCheckResult).Namespace("openshift-compliance").List(context.TODO(), metav1.ListOptions{})
+				list, err := clientManagedDynamic.Resource(gvrComplianceCheckResult).Namespace("openshift-compliance").List(context.TODO(), metav1.ListOptions{})
+				Expect(err).To(BeNil())
 				return len(list.Items)
 			}, defaultTimeoutSeconds*12, 1).ShouldNot(Equal(0))
 		})


### PR DESCRIPTION
Signed-off-by: Gus Parvin <gparvin@redhat.com>
To me it seems like we should just check for an error instead of ignore the error.
The goal of this change is to fix the failure identified in issue https://github.com/open-cluster-management/backlog/issues/14258