### PR TITLE
Enhance and document local test runs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+Refer to our [Open Cluster Management Community Code of Conduct](https://github.com/open-cluster-management/community/blob/main/CODE_OF_CONDUCT.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+**Table of Contents**
+
+- [Contributing guidelines](#contributing-guidelines)
+    - [Terms](#terms)
+    - [Certificate of Origin](#certificate-of-origin)
+    - [DCO Sign Off](#dco-sign-off)
+    - [Code of Conduct](#code-of-conduct)
+    - [Contributing a patch](#contributing-a-patch)
+    - [Issue and pull request management](#issue-and-pull-request-management)
+    - [Pre-check before submitting a PR](#pre-check-before-submitting-a-pr)
+
+# Contributing guidelines
+
+## Terms
+
+All contributions to the repository must be submitted under the terms of the [Apache Public License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+## Certificate of Origin
+
+By contributing to this project, you agree to the Developer Certificate of Origin (DCO). This document was created by the Linux Kernel community and is a simple statement that you, as a contributor, have the legal right to make the contribution. See the [DCO](https://github.com/open-cluster-management/community/blob/main/DCO) file for details.
+
+## DCO Sign Off
+
+You must sign off your commit to state that you certify the [DCO](https://github.com/open-cluster-management/community/blob/main/DCO). To certify your commit for DCO, add a line like the following at the end of your commit message:
+
+```
+Signed-off-by: John Smith <john@example.com>
+```
+
+This can be done with the `--signoff` option to `git commit`. See the [Git documentation](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) for details.
+
+## Code of Conduct
+
+The Open Cluster Management project has adopted the CNCF Code of Conduct. Refer to our [Community Code of Conduct](https://github.com/open-cluster-management/community/blob/main/CODE_OF_CONDUCT.md) for details.
+
+## Contributing a patch
+
+1. Submit an issue describing your proposed change to the repository in question. The repository owners will respond to your issue promptly.
+2. Fork the desired repository, then develop and test your code changes.
+3. Submit a pull request.
+
+## Issue and pull request management
+
+Anyone can comment on issues and submit reviews for pull requests. In order to be assigned an issue or pull request, you can leave a `/assign <your Github ID>` comment on the issue or pull request (PR).
+

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,11 @@ GITHUB_TOKEN ?=
 # Handle KinD configuration
 KIND_HUB_NAMESPACE ?= open-cluster-management
 KIND_MANAGED_NAMESPACE ?= open-cluster-management-agent-addon
-MANAGED_CLUSTER_NAME ?= cluster1
+MANAGED_CLUSTER_NAME ?= managed
 HUB_CLUSTER_NAME ?= hub
+
+# Test configuration
+TEST_FILE ?=
 
 USE_VENDORIZED_BUILD_HARNESS ?=
 
@@ -91,13 +94,13 @@ kind-deploy-policy-framework:
 	@echo creating secrets on managed
 	kubectl create ns $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 	kubectl create secret -n $(KIND_MANAGED_NAMESPACE) generic hub-kubeconfig --from-file=kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)_internal --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
-	if [ "$(deployOnHub)" = "true" ]; then\
+	@if [ "$(deployOnHub)" = "true" ]; then\
 		echo skipping installing policy-spec-sync on managed;\
 	else\
 		echo installing policy-spec-sync on managed;\
 		kubectl apply -f deploy/spec-sync -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME);\
 	fi
-	if [ "$(deployOnHub)" = "true" ]; then\
+	@if [ "$(deployOnHub)" = "true" ]; then\
 		echo installing policy-status-sync with ON_MULTICLUSTERHUB;\
 		kubectl apply -k deploy/status-sync -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME);\
 	else\
@@ -131,9 +134,9 @@ kind-create-cluster:
 	@echo "creating cluster hub"
 	kind create cluster --name $(HUB_CLUSTER_NAME)
 	kind get kubeconfig --name $(HUB_CLUSTER_NAME) > $(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)
-	# needed for mangaed -> hub communication
+	# needed for managed -> hub communication
 	kind get kubeconfig --name $(HUB_CLUSTER_NAME) --internal > $(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)_internal
-	if [ "$(deployOnHub)" = "true" ]; then\
+	@if [ "$(deployOnHub)" = "true" ]; then\
 		echo import cluster hub as managed;\
 		kind get kubeconfig --name $(HUB_CLUSTER_NAME) > $(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME);\
 	else\
@@ -145,6 +148,9 @@ kind-create-cluster:
 kind-delete-cluster:
 	kind delete cluster --name $(HUB_CLUSTER_NAME)
 	kind delete cluster --name $(MANAGED_CLUSTER_NAME)
+	rm $(PWD)/kubeconfig_$(HUB_CLUSTER_NAME) || true
+	rm $(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)_internal || true
+	rm $(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME) || true
 
 install-crds:
 	@echo installing crds on hub
@@ -164,10 +170,19 @@ install-resources:
 	kubectl apply -f test/resources/managed-cluster.yaml --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)
 	
 e2e-test:
-	ginkgo -v --slowSpecThreshold=10 test/e2e
+	@if [ -z "$(TEST_FILE)" ]; then\
+		ginkgo -v --slowSpecThreshold=10 test/e2e;\
+	else\
+		ginkgo -v --slowSpecThreshold=10 --regexScansFilePath=true --focus=$(TEST_FILE) test/e2e;\
+	fi
 
 policy-collection-test:
-	ginkgo -v --slowSpecThreshold=10 test/policy-collection
+	@if [ -z "$(TEST_FILE)" ]; then\
+		ginkgo -v --slowSpecThreshold=10 test/policy-collection;\
+	else\
+		ginkgo -v --slowSpecThreshold=10 --regexScansFilePath=true --focus=$(TEST_FILE) test/policy-collection;\
+	fi
+	
 
 travis-slack-reporter:
 	docker run --volume $(PWD)/results:/opt/app-root/src/grc-ui/test-output/e2e \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ View the following functions of the policy framework:
 * Supports multiple policy engines and policy languages.
 * Provides an extensible mechanism to bring your own policy.
 
-## Architecutre
+## Architecture
 
 ![architecture](images/policy-framework-architecture-diagram.jpg)
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,0 +1,67 @@
+# Running tests in this repository
+
+## Test folders
+
+ - `e2e`: Tests for functionality across all components
+ - `policy-collection`: Tests for policies in the [policy-collection](https://github.com/open-cluster-management/policy-collection) repository
+
+## Cluster configuration
+
+*Prerequisites*
+- `go`
+- `kubectl`
+- `kind` and `docker` (if you're running the tests on Kind)
+
+*NOTES*
+- The tests look for `kubeconfig` files in the root of the local repository directory to authenticate to a Hub and Managed cluster:
+  - `kubeconfig_hub`
+  - `kubeconfig_managed`
+- To use a self-managed Hub for the tests, export `deployOnHub=true` and use the same file for both kubeconfigs.
+
+### On Local Kind Clusters
+
+```shell
+export deployOnHub=true
+make kind-bootstrap-cluster
+```
+
+For a hub with a managed cluster attached:
+```shell
+make kind-bootstrap-cluster
+```
+
+### On External Clusters (like Openshift)
+
+For hub-only:
+```shell
+cp <path/to/hub/kubeconfig> ./kubeconfig_hub
+cp ./kubeconfig_hub ./kubeconfig_managed
+export deployOnHub=true
+export MANAGED_CLUSTER_NAME=local-cluster
+```
+
+For a hub with a managed cluster attached:
+```shell
+cp <path/to/hub/kubeconfig> ./kubeconfig_hub
+cp <path/to/managed/kubeconfig> ./kubeconfig_managed
+export MANAGED_CLUSTER_NAME=<managed_cluster_name_on_hub>
+```
+
+## Test Runs
+
+If there's a particular test file you want to run, export the name of the test file to `TEST_FILE` (with or without the path):
+```shell
+export TEST_FILE=<filename_test.go>
+```
+
+### E2E
+
+```shell
+make e2e-test
+```
+
+### Policy Collection
+
+```shell
+make policy-collection-test
+```

--- a/doc/development.md
+++ b/doc/development.md
@@ -20,6 +20,7 @@
 
 ### On Local Kind Clusters
 
+For hub-only:
 ```shell
 export deployOnHub=true
 make kind-bootstrap-cluster

--- a/doc/development.md
+++ b/doc/development.md
@@ -31,6 +31,11 @@ For a hub with a managed cluster attached:
 make kind-bootstrap-cluster
 ```
 
+To delete the clusters and the `kubeconfig` files:
+```shell
+make kind-delete-cluster
+```
+
 ### On external clusters with Open Cluster Management already installed
 
 For hub-only:

--- a/doc/development.md
+++ b/doc/development.md
@@ -31,7 +31,7 @@ For a hub with a managed cluster attached:
 make kind-bootstrap-cluster
 ```
 
-### On External Clusters (like Openshift)
+### On external clusters with Open Cluster Management already installed
 
 For hub-only:
 ```shell

--- a/doc/development.md
+++ b/doc/development.md
@@ -7,12 +7,12 @@
 
 ## Cluster configuration
 
-*Prerequisites*
+**Prerequisites**
 - `go`
 - `kubectl`
 - `kind` and `docker` (if you're running the tests on Kind)
 
-*NOTES*
+**NOTES**
 - The tests look for `kubeconfig` files in the root of the local repository directory to authenticate to a Hub and Managed cluster:
   - `kubeconfig_hub`
   - `kubeconfig_managed`

--- a/test/policy-collection/policy_collection_suite_test.go
+++ b/test/policy-collection/policy_collection_suite_test.go
@@ -1,7 +1,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 package e2e
 
 import (


### PR DESCRIPTION
- Adds `TEST_FILE` flag for running individual test files
- Adds a file `doc/development.md` to document how to run tests locally
- Update the open source files to comply with open source requirements