### PR TITLE
Update community gatekeeper controller name

### DIFF
--- a/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
@@ -97,7 +97,7 @@ var _ = Describe("RHACM4K-3055", func() {
 				podList, err := clientManaged.CoreV1().Pods("openshift-operators").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane in (controller-manager, gatekeeper-operator-controller-manager)"})
 				Expect(err).To(BeNil())
 				for _, item := range podList.Items {
-					if strings.HasPrefix(item.ObjectMeta.Name, "gatekeeper-operator-controller-manager") {
+					if strings.HasPrefix(item.ObjectMeta.Name, "gatekeeper-operator-controller") {
 						return string(item.Status.Phase)
 					}
 				}


### PR DESCRIPTION
Previously the name was gatekeeper-operator-controller-manager-xxx, but
in newer versions it might just be gatekeeper-operator-controller-xxx.
Because of the nature of this change, the test will check for the pod
regardless of which version was installed.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>