### PR TITLE
Upstream gk ctrl name

### DIFF
--- a/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
@@ -97,7 +97,7 @@ var _ = Describe("RHACM4K-3055", func() {
 				podList, err := clientManaged.CoreV1().Pods("openshift-operators").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane in (controller-manager, gatekeeper-operator-controller-manager)"})
 				Expect(err).To(BeNil())
 				for _, item := range podList.Items {
-					if strings.HasPrefix(item.ObjectMeta.Name, "gatekeeper-operator-controller-manager") {
+					if strings.HasPrefix(item.ObjectMeta.Name, "gatekeeper-operator-controller") {
 						return string(item.Status.Phase)
 					}
 				}

--- a/test/policy-collection/policy_gatekeeper_operator_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_test.go
@@ -145,7 +145,7 @@ var _ = Describe("", func() {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-operator").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane in (controller-manager, gatekeeper-operator-controller-manager)"})
 				Expect(err).To(BeNil())
 				for _, item := range podList.Items {
-					if strings.HasPrefix(item.ObjectMeta.Name, "gatekeeper-operator-controller-manager") {
+					if strings.HasPrefix(item.ObjectMeta.Name, "gatekeeper-operator-controller") {
 						return string(item.Status.Phase)
 					}
 				}


### PR DESCRIPTION
In https://github.com/open-cluster-management/governance-policy-framework/pull/127, I meant to update in the *upstream* tests, but mistakenly only added it to the *downstream* tests. Looks like this is still the only e2e test failure at this point.