### PR TITLE
[release-2.2] Fix publishing old images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,11 @@ jobs:
       if: type = push AND branch =~ /^release-[0-9]+\..*$/
       script:
         - set -e
+        - export COMPONENT_BUILD_COMMAND="docker build . -f Dockerfile.e2etest -t "
+        - export COMPONENT_NAME="grc-policy-framework-tests"
+        - go mod vendor
+        - make component/build
+        - make component/push
         - make pipeline-manifest/update COMPONENT_NAME=grc-policy-framework-tests PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
   
 notifications:


### PR DESCRIPTION
Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>

Old branches were not publishing their test image, which meant that the canaries couldn't pull the updated image. One Slack thread about this: https://coreos.slack.com/archives/C01KV8QDATA/p1628803129010600

We hadn't previously run into this because it looks like we hadn't had to backport any changes here until the gatekeeper problems.

