### PR TITLE
Move common test setup to separate package

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -1,0 +1,92 @@
+package common
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+)
+
+var (
+	KubeconfigHub         string
+	KubeconfigManaged     string
+	UserNamespace         string
+	ClusterNamespace      string
+	DefaultTimeoutSeconds int
+)
+
+func init() {
+	flag.StringVar(&KubeconfigHub, "kubeconfig_hub", "../../kubeconfig_hub", "Location of the kubeconfig to use; defaults to KUBECONFIG if not set")
+	flag.StringVar(&KubeconfigManaged, "kubeconfig_managed", "../../kubeconfig_managed", "Location of the kubeconfig to use; defaults to KUBECONFIG if not set")
+	flag.StringVar(&UserNamespace, "user_namespace", "policy-test", "ns on hub to create root policy")
+	flag.StringVar(&ClusterNamespace, "cluster_namespace", "local-cluster", "cluster ns name")
+	flag.IntVar(&DefaultTimeoutSeconds, "timeout_seconds", 30, "Timeout seconds for assertion")
+}
+
+func NewKubeClient(url, kubeconfig, context string) kubernetes.Interface {
+	klog.V(5).Infof("Create kubeclient for url %s using kubeconfig path %s\n", url, kubeconfig)
+	config, err := LoadConfig(url, kubeconfig, context)
+	if err != nil {
+		panic(err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+
+	return clientset
+}
+
+func NewKubeClientDynamic(url, kubeconfig, context string) dynamic.Interface {
+	klog.V(5).Infof("Create kubeclient dynamic for url %s using kubeconfig path %s\n", url, kubeconfig)
+	config, err := LoadConfig(url, kubeconfig, context)
+	if err != nil {
+		panic(err)
+	}
+
+	clientset, err := dynamic.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+
+	return clientset
+}
+
+func LoadConfig(url, kubeconfig, context string) (*rest.Config, error) {
+	if kubeconfig == "" {
+		kubeconfig = os.Getenv("KUBECONFIG")
+	}
+	klog.V(5).Infof("Kubeconfig path %s\n", kubeconfig)
+	// If we have an explicit indication of where the kubernetes config lives, read that.
+	if kubeconfig != "" {
+		if context == "" {
+			return clientcmd.BuildConfigFromFlags(url, kubeconfig)
+		}
+		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+			&clientcmd.ConfigOverrides{
+				CurrentContext: context,
+			}).ClientConfig()
+	}
+	// If not, try the in-cluster config.
+	if c, err := rest.InClusterConfig(); err == nil {
+		return c, nil
+	}
+	// If no in-cluster config, try the default location in the user's home directory.
+	if usr, err := user.Current(); err == nil {
+		klog.V(5).Infof("clientcmd.BuildConfigFromFlags for url %s using %s\n", url, filepath.Join(usr.HomeDir, ".kube", "config"))
+		if c, err := clientcmd.BuildConfigFromFlags("", filepath.Join(usr.HomeDir, ".kube", "config")); err == nil {
+			return c, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not create a valid kubeconfig")
+}

--- a/test/common/gvr.go
+++ b/test/common/gvr.go
@@ -1,0 +1,21 @@
+package common
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+var (
+	GvrPod                   = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+	GvrNS                    = schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
+	GvrRole                  = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
+	GvrCRD                   = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"}
+	GvrPolicy                = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policies"}
+	GvrConfigurationPolicy   = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "configurationpolicies"}
+	GvrCertPolicy            = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "certificatepolicies"}
+	GvrIamPolicy             = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "iampolicies"}
+	GvrPlacementBinding      = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "placementbindings"}
+	GvrPlacementRule         = schema.GroupVersionResource{Group: "apps.open-cluster-management.io", Version: "v1", Resource: "placementrules"}
+	GvrK8sRequiredLabels     = schema.GroupVersionResource{Group: "constraints.gatekeeper.sh", Version: "v1beta1", Resource: "k8srequiredlabels"}
+	GvrClusterVersion        = schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "clusterversions"}
+	GvrComplianceScan        = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancescans"}
+	GvrComplianceSuite       = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancesuites"}
+	GvrComplianceCheckResult = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancecheckresults"}
+)

--- a/test/e2e/cert_policy_test.go
+++ b/test/e2e/cert_policy_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/open-cluster-management/governance-policy-framework/test/common"
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -24,22 +25,22 @@ var _ = Describe("Test cert policy", func() {
 		It("should be created on managed cluster", func() {
 			By("Creating " + certPolicyYaml)
 			utils.Kubectl("apply", "-f", certPolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
-			hubPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+			hubPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 			Expect(hubPlc).NotTo(BeNil())
 			By("Patching " + certPolicyName + "-plr with decision of cluster managed")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, certPolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(clientHubDynamic, common.GvrPlacementRule, certPolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(common.GvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
 			Expect(err).To(BeNil())
 			By("Checking " + certPolicyName + " on managed cluster in ns " + clusterNamespace)
-			managedplc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+certPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+			managedplc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+certPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(managedplc).NotTo(BeNil())
 		})
 		It("the policy should be compliant as there is no certificate", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -51,7 +52,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -61,7 +62,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -73,7 +74,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 			By("Creating ../resources/cert_policy/certificate_compliant.yaml in ns default")
@@ -81,7 +82,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc = utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -93,7 +94,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -103,7 +104,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -115,7 +116,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -125,7 +126,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -137,7 +138,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -147,7 +148,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -159,7 +160,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -169,7 +170,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -181,7 +182,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -191,7 +192,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/cert_policy/" + certPolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, certPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -199,10 +200,10 @@ var _ = Describe("Test cert policy", func() {
 			By("Deleting " + certPolicyYaml)
 			utils.Kubectl("delete", "-f", certPolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
 			By("Checking if there is any policy left")
-			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
-			utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientHubDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 			By("Checking if there is any cert policy left")
-			utils.ListWithTimeout(clientManagedDynamic, gvrCertPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrCertPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 			By("Deleting ../resources/cert_policy/issuer.yaml in ns default")
 			utils.Kubectl("delete", "-f", "../resources/cert_policy/issuer.yaml", "-n", "default", "--kubeconfig=../../kubeconfig_managed")
 			By("Deleting ../resources/cert_policy/certificate.yaml in ns default")

--- a/test/e2e/configuration_policy_test.go
+++ b/test/e2e/configuration_policy_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/open-cluster-management/governance-policy-framework/test/common"
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,22 +20,22 @@ var _ = Describe("Test configuration policy", func() {
 		It("should be created on managed cluster", func() {
 			By("Creating " + rolePolicyYaml)
 			utils.Kubectl("apply", "-f", rolePolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
-			hubPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+			hubPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 			Expect(hubPlc).NotTo(BeNil())
 			By("Patching " + rolePolicyName + "-plr with decision of cluster managed")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, rolePolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(clientHubDynamic, common.GvrPlacementRule, rolePolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(common.GvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
 			Expect(err).To(BeNil())
 			By("Checking " + rolePolicyName + " on managed cluster in ns " + clusterNamespace)
-			managedplc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+rolePolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+			managedplc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+rolePolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(managedplc).NotTo(BeNil())
 		})
 		It("the policy should be noncompliant", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -44,7 +45,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -54,7 +55,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -64,7 +65,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -74,7 +75,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -84,7 +85,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -94,7 +95,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -102,10 +103,10 @@ var _ = Describe("Test configuration policy", func() {
 			By("Deleting " + rolePolicyYaml)
 			utils.Kubectl("delete", "-f", rolePolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
 			By("Checking if there is any policy left")
-			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
-			utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientHubDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 			By("Checking if there is any configuration policy left")
-			utils.ListWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 		})
 	})
 	Describe("Test object musthave enforce", func() {
@@ -114,35 +115,35 @@ var _ = Describe("Test configuration policy", func() {
 		It("should be created on managed cluster", func() {
 			By("Creating " + rolePolicyYaml)
 			utils.Kubectl("apply", "-f", rolePolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
-			hubPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+			hubPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 			Expect(hubPlc).NotTo(BeNil())
 			By("Patching " + rolePolicyName + "-plr with decision of cluster managed")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, rolePolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(clientHubDynamic, common.GvrPlacementRule, rolePolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(common.GvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
 			Expect(err).To(BeNil())
 			By("Checking " + rolePolicyName + " on managed cluster in ns " + clusterNamespace)
-			managedplc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+rolePolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+			managedplc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+rolePolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(managedplc).NotTo(BeNil())
 		})
 		It("the policy should be noncompliant", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
 		It("the policy should be compliant after enforcing it", func() {
 			By("Patching remediationAction = enforce on root policy")
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 			rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-			rootPlc, _ = clientHubDynamic.Resource(gvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+			rootPlc, _ = clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
 			Expect(rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]).To(Equal("enforce"))
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -151,20 +152,20 @@ var _ = Describe("Test configuration policy", func() {
 			utils.Kubectl("delete", "role", "-n", "default", "--all", "--kubeconfig=../../kubeconfig_managed")
 			By("Checking if the role has been deleted")
 			Eventually(func() interface{} {
-				roleList, err := clientManagedDynamic.Resource(gvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
+				roleList, err := clientManagedDynamic.Resource(common.GvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil())
 				return len(roleList.Items)
 			}, defaultTimeoutSeconds, 1).Should(Equal(0))
 			By("Checking if the role has been recreated")
 			Eventually(func() interface{} {
-				roleList, err := clientManagedDynamic.Resource(gvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
+				roleList, err := clientManagedDynamic.Resource(common.GvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil())
 				return len(roleList.Items)
 			}, defaultTimeoutSeconds, 1).Should(Equal(1))
 			By("Checking if the status of root policy is still compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -175,17 +176,17 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the role is not patched to match in 20s")
 			yamlRole := utils.ParseYaml("../resources/configuration_policy/role-policy-e2e-more.yaml")
 			Eventually(func() interface{} {
-				managedRole := utils.GetWithTimeout(clientManagedDynamic, gvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
+				managedRole := utils.GetWithTimeout(clientManagedDynamic, common.GvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
 				return managedRole.Object["rules"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 			Consistently(func() interface{} {
-				managedRole := utils.GetWithTimeout(clientManagedDynamic, gvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
+				managedRole := utils.GetWithTimeout(clientManagedDynamic, common.GvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
 				return managedRole.Object["rules"]
 			}, 20, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 			By("Checking if the status of root policy is still compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -195,13 +196,13 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the role has been patched to match")
 			yamlRole := utils.ParseYaml("../resources/configuration_policy/role-policy-e2e.yaml")
 			Eventually(func() interface{} {
-				managedRole := utils.GetWithTimeout(clientManagedDynamic, gvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
+				managedRole := utils.GetWithTimeout(clientManagedDynamic, common.GvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
 				return managedRole.Object["rules"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 			By("Checking if the status of root policy is still compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -210,16 +211,16 @@ var _ = Describe("Test configuration policy", func() {
 			By("Deleting " + rolePolicyYaml)
 			utils.Kubectl("delete", "-f", rolePolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
 			By("Checking if there is any policy left")
-			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
-			utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientHubDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 			By("Checking if there is any configuration policy left")
-			utils.ListWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 			By("Deleting the role in default namespace on managed cluster")
 			utils.Pause(15)
 			utils.Kubectl("delete", "role", "-n", "default", "--all", "--kubeconfig=../../kubeconfig_managed")
 			By("Checking if there is any role left")
 			Eventually(func() interface{} {
-				roleList, err := clientManagedDynamic.Resource(gvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
+				roleList, err := clientManagedDynamic.Resource(common.GvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil())
 				return len(roleList.Items)
 			}, defaultTimeoutSeconds, 1).Should(Equal(0))
@@ -231,22 +232,22 @@ var _ = Describe("Test configuration policy", func() {
 		It("should be created on managed cluster", func() {
 			By("Creating " + rolePolicyYaml)
 			utils.Kubectl("apply", "-f", rolePolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
-			hubPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+			hubPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 			Expect(hubPlc).NotTo(BeNil())
 			By("Patching " + rolePolicyName + "-plr with decision of cluster managed")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, rolePolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(clientHubDynamic, common.GvrPlacementRule, rolePolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(common.GvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
 			Expect(err).To(BeNil())
 			By("Checking " + rolePolicyName + " on managed cluster in ns " + clusterNamespace)
-			managedplc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+rolePolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+			managedplc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+rolePolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(managedplc).NotTo(BeNil())
 		})
 		It("the policy should be compliant", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -256,7 +257,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -266,7 +267,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -274,10 +275,10 @@ var _ = Describe("Test configuration policy", func() {
 			By("Deleting " + rolePolicyYaml)
 			utils.Kubectl("delete", "-f", rolePolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
 			By("Checking if there is any policy left")
-			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
-			utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientHubDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 			By("Checking if there is any configuration policy left")
-			utils.ListWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 		})
 	})
 	Describe("Test object mustnothave enforce", func() {
@@ -286,22 +287,22 @@ var _ = Describe("Test configuration policy", func() {
 		It("should be created on managed cluster", func() {
 			By("Creating " + rolePolicyYaml)
 			utils.Kubectl("apply", "-f", rolePolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
-			hubPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+			hubPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 			Expect(hubPlc).NotTo(BeNil())
 			By("Patching " + rolePolicyName + "-plr with decision of cluster managed")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, rolePolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(clientHubDynamic, common.GvrPlacementRule, rolePolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(common.GvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
 			Expect(err).To(BeNil())
 			By("Checking " + rolePolicyName + " on managed cluster in ns " + clusterNamespace)
-			managedplc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+rolePolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+			managedplc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+rolePolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(managedplc).NotTo(BeNil())
 		})
 		It("the policy should be compliant", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -311,20 +312,20 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
 		It("the policy should be compliant after enforcing it", func() {
 			By("Patching remediationAction = enforce on root policy")
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 			rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-			rootPlc, _ = clientHubDynamic.Resource(gvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+			rootPlc, _ = clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
 			Expect(rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]).To(Equal("enforce"))
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -334,14 +335,14 @@ var _ = Describe("Test configuration policy", func() {
 			utils.Pause(20)
 			By("Checking if the role has been deleted")
 			Eventually(func() interface{} {
-				roleList, err := clientManagedDynamic.Resource(gvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
+				roleList, err := clientManagedDynamic.Resource(common.GvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil())
 				return len(roleList.Items)
 			}, defaultTimeoutSeconds, 1).Should(Equal(0))
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -349,10 +350,10 @@ var _ = Describe("Test configuration policy", func() {
 			By("Deleting " + rolePolicyYaml)
 			utils.Kubectl("delete", "-f", rolePolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
 			By("Checking if there is any policy left")
-			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
-			utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientHubDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 			By("Checking if there is any configuration policy left")
-			utils.ListWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 		})
 	})
 	Describe("Test object mustonlyhave inform", func() {
@@ -361,22 +362,22 @@ var _ = Describe("Test configuration policy", func() {
 		It("should be created on managed cluster", func() {
 			By("Creating " + rolePolicyYaml)
 			utils.Kubectl("apply", "-f", rolePolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
-			hubPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+			hubPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 			Expect(hubPlc).NotTo(BeNil())
 			By("Patching " + rolePolicyName + "-plr with decision of cluster managed")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, rolePolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(clientHubDynamic, common.GvrPlacementRule, rolePolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(common.GvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
 			Expect(err).To(BeNil())
 			By("Checking " + rolePolicyName + " on managed cluster in ns " + clusterNamespace)
-			managedplc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+rolePolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+			managedplc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+rolePolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(managedplc).NotTo(BeNil())
 		})
 		It("the policy should be noncompliant", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -386,7 +387,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -396,7 +397,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -406,7 +407,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -416,7 +417,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -426,7 +427,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -436,7 +437,7 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -444,10 +445,10 @@ var _ = Describe("Test configuration policy", func() {
 			By("Deleting " + rolePolicyYaml)
 			utils.Kubectl("delete", "-f", rolePolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
 			By("Checking if there is any policy left")
-			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
-			utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientHubDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 			By("Checking if there is any configuration policy left")
-			utils.ListWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 		})
 	})
 	Describe("Test object mustonlyhave enforce", func() {
@@ -456,24 +457,24 @@ var _ = Describe("Test configuration policy", func() {
 		It("should be created on managed cluster", func() {
 			By("Creating " + rolePolicyYaml)
 			utils.Kubectl("apply", "-f", rolePolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
-			hubPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+			hubPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 			Expect(hubPlc).NotTo(BeNil())
 			By("Patching " + rolePolicyName + "-plr with decision of cluster managed")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, rolePolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(clientHubDynamic, common.GvrPlacementRule, rolePolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(common.GvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
 			Expect(err).To(BeNil())
 			By("Checking " + rolePolicyName + " on managed cluster in ns " + clusterNamespace)
-			managedplc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+rolePolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+			managedplc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+rolePolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(managedplc).NotTo(BeNil())
 		})
 		It("the policy should be compliant after enforcing it", func() {
 			By("Patching remediationAction = enforce on root policy")
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 			rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-			clientHubDynamic.Resource(gvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+			clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				remediation, ok := rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]
 				if !ok {
 					return nil
@@ -483,14 +484,14 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
 		It("the role should be created by policy", func() {
 			By("Checking if the role has been created")
 			Eventually(func() interface{} {
-				roleList, err := clientManagedDynamic.Resource(gvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
+				roleList, err := clientManagedDynamic.Resource(common.GvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil())
 				return len(roleList.Items)
 			}, defaultTimeoutSeconds, 1).Should(Equal(1))
@@ -500,20 +501,20 @@ var _ = Describe("Test configuration policy", func() {
 			utils.Kubectl("delete", "role", "-n", "default", "--all", "--kubeconfig=../../kubeconfig_managed")
 			By("Checking if the role has been deleted")
 			Eventually(func() interface{} {
-				roleList, err := clientManagedDynamic.Resource(gvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
+				roleList, err := clientManagedDynamic.Resource(common.GvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil())
 				return len(roleList.Items)
 			}, defaultTimeoutSeconds, 1).Should(Equal(0))
 			By("Checking if the role has been recreated")
 			Eventually(func() interface{} {
-				roleList, err := clientManagedDynamic.Resource(gvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
+				roleList, err := clientManagedDynamic.Resource(common.GvrRole).Namespace("default").List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil())
 				return len(roleList.Items)
 			}, defaultTimeoutSeconds, 1).Should(Equal(1))
 			By("Checking if the status of root policy is still compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -523,19 +524,19 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the role has been patched to have less rules")
 			yamlRole := utils.ParseYaml("../resources/configuration_policy/role-policy-e2e-less.yaml")
 			Eventually(func() interface{} {
-				managedRole := utils.GetWithTimeout(clientManagedDynamic, gvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
+				managedRole := utils.GetWithTimeout(clientManagedDynamic, common.GvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
 				return managedRole.Object["rules"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 			By("Checking if the role has been patched to match by config policy")
 			yamlRole = utils.ParseYaml("../resources/configuration_policy/role-policy-e2e.yaml")
 			Eventually(func() interface{} {
-				managedRole := utils.GetWithTimeout(clientManagedDynamic, gvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
+				managedRole := utils.GetWithTimeout(clientManagedDynamic, common.GvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
 				return managedRole.Object["rules"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 			By("Checking if the status of root policy is still compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -545,19 +546,19 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the role has been patched to have more rules")
 			yamlRole := utils.ParseYaml("../resources/configuration_policy/role-policy-e2e-more.yaml")
 			Eventually(func() interface{} {
-				managedRole := utils.GetWithTimeout(clientManagedDynamic, gvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
+				managedRole := utils.GetWithTimeout(clientManagedDynamic, common.GvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
 				return managedRole.Object["rules"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 			By("Checking if the role has been patched to match by config policy")
 			yamlRole = utils.ParseYaml("../resources/configuration_policy/role-policy-e2e.yaml")
 			Eventually(func() interface{} {
-				managedRole := utils.GetWithTimeout(clientManagedDynamic, gvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
+				managedRole := utils.GetWithTimeout(clientManagedDynamic, common.GvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
 				return managedRole.Object["rules"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 			By("Checking if the status of root policy is still compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -567,19 +568,19 @@ var _ = Describe("Test configuration policy", func() {
 			By("Checking if the role has been patched to mismatch")
 			yamlRole := utils.ParseYaml("../resources/configuration_policy/role-policy-e2e-mismatch.yaml")
 			Eventually(func() interface{} {
-				managedRole := utils.GetWithTimeout(clientManagedDynamic, gvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
+				managedRole := utils.GetWithTimeout(clientManagedDynamic, common.GvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
 				return managedRole.Object["rules"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 			By("Checking if the role has been patched to match by config policy")
 			yamlRole = utils.ParseYaml("../resources/configuration_policy/role-policy-e2e.yaml")
 			Eventually(func() interface{} {
-				managedRole := utils.GetWithTimeout(clientManagedDynamic, gvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
+				managedRole := utils.GetWithTimeout(clientManagedDynamic, common.GvrRole, "role-policy-e2e", "default", true, defaultTimeoutSeconds)
 				return managedRole.Object["rules"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 			By("Checking if the status of root policy is still compliant")
 			yamlPlc := utils.ParseYaml("../resources/configuration_policy/" + rolePolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, rolePolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -587,10 +588,10 @@ var _ = Describe("Test configuration policy", func() {
 			By("Deleting " + rolePolicyYaml)
 			utils.Kubectl("delete", "-f", rolePolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
 			By("Checking if there is any policy left")
-			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
-			utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientHubDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 			By("Checking if there is any configuration policy left")
-			utils.ListWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 			By("Deleting the role in default namespace on managed cluster")
 			utils.Kubectl("delete", "role", "-n", "default", "--all", "--kubeconfig=../../kubeconfig_managed")
 		})

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -5,50 +5,41 @@ package e2e
 
 import (
 	"context"
-	"flag"
-	"fmt"
-	"os"
-	"os/user"
-	"path/filepath"
-	"strconv"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/open-cluster-management/governance-policy-framework/test/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 )
 
 var (
-	userNamespace          string
-	clusterNamespace       string
-	clientHub              kubernetes.Interface
-	clientHubDynamic       dynamic.Interface
-	clientManaged          kubernetes.Interface
-	clientManagedDynamic   dynamic.Interface
-	gvrPod                 schema.GroupVersionResource
-	gvrPolicy              schema.GroupVersionResource
-	gvrIamPolicy           schema.GroupVersionResource
-	gvrCertPolicy          schema.GroupVersionResource
-	gvrConfigurationPolicy schema.GroupVersionResource
-	gvrPlacementBinding    schema.GroupVersionResource
-	gvrPlacementRule       schema.GroupVersionResource
-	gvrRole                schema.GroupVersionResource
-	gvrCRD                 schema.GroupVersionResource
-	gvrNS                  schema.GroupVersionResource
-	gvrK8sRequiredLabels   schema.GroupVersionResource
-	kubeconfigHub          string
-	kubeconfigManaged      string
-	defaultTimeoutSeconds  int
+	clusterNamespace = "managed"
 
-	defaultImageRegistry string
+	defaultTimeoutSeconds int
+	userNamespace         string
+	clientHub             kubernetes.Interface
+	clientHubDynamic      dynamic.Interface
+	clientManaged         kubernetes.Interface
+	clientManagedDynamic  dynamic.Interface
+
+	gvrPod                 = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+	gvrNS                  = schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
+	gvrRole                = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
+	gvrCRD                 = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"}
+	gvrPolicy              = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policies"}
+	gvrConfigurationPolicy = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "configurationpolicies"}
+	gvrCertPolicy          = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "certificatepolicies"}
+	gvrIamPolicy           = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "iampolicies"}
+	gvrPlacementBinding    = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "placementbindings"}
+	gvrPlacementRule       = schema.GroupVersionResource{Group: "apps.open-cluster-management.io", Version: "v1", Resource: "placementrules"}
+	gvrK8sRequiredLabels   = schema.GroupVersionResource{Group: "constraints.gatekeeper.sh", Version: "v1beta1", Resource: "k8srequiredlabels"}
 )
 
 func TestE2e(t *testing.T) {
@@ -59,42 +50,19 @@ func TestE2e(t *testing.T) {
 func init() {
 	klog.SetOutput(GinkgoWriter)
 	klog.InitFlags(nil)
-	flag.StringVar(&kubeconfigHub, "kubeconfig_hub", "../../kubeconfig_hub", "Location of the kubeconfig to use; defaults to KUBECONFIG if not set")
-	flag.StringVar(&kubeconfigManaged, "kubeconfig_managed", "../../kubeconfig_managed", "Location of the kubeconfig to use; defaults to KUBECONFIG if not set")
-
 }
 
 var _ = BeforeSuite(func() {
 	By("Setup hub and managed client")
-	gvrPod = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
-	gvrPolicy = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policies"}
-	gvrConfigurationPolicy = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "configurationpolicies"}
-	gvrCertPolicy = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "certificatepolicies"}
-	gvrIamPolicy = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "iampolicies"}
-	gvrPlacementBinding = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "placementbindings"}
-	gvrPlacementRule = schema.GroupVersionResource{Group: "apps.open-cluster-management.io", Version: "v1", Resource: "placementrules"}
-	gvrRole = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
-	gvrCRD = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"}
-	gvrNS = schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
-	gvrK8sRequiredLabels = schema.GroupVersionResource{Group: "constraints.gatekeeper.sh", Version: "v1beta1", Resource: "k8srequiredlabels"}
-	clientHub = NewKubeClient("", kubeconfigHub, "")
-	clientHubDynamic = NewKubeClientDynamic("", kubeconfigHub, "")
-	clientManaged = NewKubeClient("", kubeconfigManaged, "")
-	clientManagedDynamic = NewKubeClientDynamic("", kubeconfigManaged, "")
-	defaultImageRegistry = "quay.io/open-cluster-management"
-	userNamespace = "policy-test"
-	clusterNamespace = "managed"
-	timeoutStr, found := os.LookupEnv("E2E_TIMEOUT_SECONDS")
-	if !found {
-		defaultTimeoutSeconds = 30
-	} else {
-		if n, err := strconv.Atoi(timeoutStr); err == nil {
-			defaultTimeoutSeconds = n
-		} else {
-			defaultTimeoutSeconds = 30
-		}
-	}
-	By("Create Namesapce if needed")
+	userNamespace = common.UserNamespace
+	defaultTimeoutSeconds = common.DefaultTimeoutSeconds
+
+	clientHub = common.NewKubeClient("", common.KubeconfigHub, "")
+	clientHubDynamic = common.NewKubeClientDynamic("", common.KubeconfigHub, "")
+	clientManaged = common.NewKubeClient("", common.KubeconfigManaged, "")
+	clientManagedDynamic = common.NewKubeClientDynamic("", common.KubeconfigManaged, "")
+
+	By("Create Namespace if needed")
 	namespaces := clientHub.CoreV1().Namespaces()
 	if _, err := namespaces.Get(context.TODO(), userNamespace, metav1.GetOptions{}); err != nil && errors.IsNotFound(err) {
 		Expect(namespaces.Create(context.TODO(), &corev1.Namespace{
@@ -105,65 +73,3 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(namespaces.Get(context.TODO(), userNamespace, metav1.GetOptions{})).NotTo(BeNil())
 })
-
-func NewKubeClient(url, kubeconfig, context string) kubernetes.Interface {
-	klog.V(5).Infof("Create kubeclient for url %s using kubeconfig path %s\n", url, kubeconfig)
-	config, err := LoadConfig(url, kubeconfig, context)
-	if err != nil {
-		panic(err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		panic(err)
-	}
-
-	return clientset
-}
-
-func NewKubeClientDynamic(url, kubeconfig, context string) dynamic.Interface {
-	klog.V(5).Infof("Create kubeclient dynamic for url %s using kubeconfig path %s\n", url, kubeconfig)
-	config, err := LoadConfig(url, kubeconfig, context)
-	if err != nil {
-		panic(err)
-	}
-
-	clientset, err := dynamic.NewForConfig(config)
-	if err != nil {
-		panic(err)
-	}
-
-	return clientset
-}
-
-func LoadConfig(url, kubeconfig, context string) (*rest.Config, error) {
-	if kubeconfig == "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-	}
-	klog.V(5).Infof("Kubeconfig path %s\n", kubeconfig)
-	// If we have an explicit indication of where the kubernetes config lives, read that.
-	if kubeconfig != "" {
-		if context == "" {
-			return clientcmd.BuildConfigFromFlags(url, kubeconfig)
-		}
-		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
-			&clientcmd.ConfigOverrides{
-				CurrentContext: context,
-			}).ClientConfig()
-	}
-	// If not, try the in-cluster config.
-	if c, err := rest.InClusterConfig(); err == nil {
-		return c, nil
-	}
-	// If no in-cluster config, try the default location in the user's home directory.
-	if usr, err := user.Current(); err == nil {
-		klog.V(5).Infof("clientcmd.BuildConfigFromFlags for url %s using %s\n", url, filepath.Join(usr.HomeDir, ".kube", "config"))
-		if c, err := clientcmd.BuildConfigFromFlags("", filepath.Join(usr.HomeDir, ".kube", "config")); err == nil {
-			return c, nil
-		}
-	}
-
-	return nil, fmt.Errorf("could not create a valid kubeconfig")
-
-}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
@@ -28,18 +27,6 @@ var (
 	clientHubDynamic      dynamic.Interface
 	clientManaged         kubernetes.Interface
 	clientManagedDynamic  dynamic.Interface
-
-	gvrPod                 = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
-	gvrNS                  = schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
-	gvrRole                = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
-	gvrCRD                 = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"}
-	gvrPolicy              = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policies"}
-	gvrConfigurationPolicy = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "configurationpolicies"}
-	gvrCertPolicy          = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "certificatepolicies"}
-	gvrIamPolicy           = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "iampolicies"}
-	gvrPlacementBinding    = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "placementbindings"}
-	gvrPlacementRule       = schema.GroupVersionResource{Group: "apps.open-cluster-management.io", Version: "v1", Resource: "placementrules"}
-	gvrK8sRequiredLabels   = schema.GroupVersionResource{Group: "constraints.gatekeeper.sh", Version: "v1beta1", Resource: "k8srequiredlabels"}
 )
 
 func TestE2e(t *testing.T) {

--- a/test/e2e/gatekeeper_test.go
+++ b/test/e2e/gatekeeper_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/open-cluster-management/governance-policy-framework/test/common"
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,20 +60,20 @@ var _ = Describe("Test gatekeeper", func() {
 		It("gatekeeper operator policy should be created on managed", func() {
 			By("Creating policy on hub")
 			utils.Kubectl("apply", "-f", GKOPolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
-			hubPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, GKOPolicyName, userNamespace, true, defaultTimeoutSeconds)
+			hubPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, GKOPolicyName, userNamespace, true, defaultTimeoutSeconds)
 			Expect(hubPlc).NotTo(BeNil())
 			By("Patching " + GKOPolicyName + " pr with decision of cluster managed")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, "placement-"+GKOPolicyName, userNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(clientHubDynamic, common.GvrPlacementRule, "placement-"+GKOPolicyName, userNamespace, true, defaultTimeoutSeconds)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(common.GvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
 			Expect(err).To(BeNil())
 			By("Checking " + GKOPolicyName + " on managed cluster in ns " + clusterNamespace)
-			managedplc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+GKOPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+			managedplc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+GKOPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(managedplc).NotTo(BeNil())
 		})
 		It("should create gatekeeper pods on managed cluster", func() {
 			By("Checking number of pods in gatekeeper-system ns")
-			utils.ListWithTimeoutByNamespace(clientManagedDynamic, gvrPod, metav1.ListOptions{}, "gatekeeper-system", 6, true, 240)
+			utils.ListWithTimeoutByNamespace(clientManagedDynamic, common.GvrPod, metav1.ListOptions{}, "gatekeeper-system", 6, true, 240)
 		})
 	})
 	Describe("Test gatekeeper policy creation", func() {
@@ -82,55 +83,55 @@ var _ = Describe("Test gatekeeper", func() {
 		const cfgpolauditName string = "policy-gatekeeper-audit"
 		const cfgpoladmissionName string = "policy-gatekeeper-admission"
 		It("should deploy gatekeeper release on managed cluster", func() {
-			configCRD := GetClusterLevelWithTimeout(clientManagedDynamic, gvrCRD, "configs.config.gatekeeper.sh", true, defaultTimeoutSeconds)
+			configCRD := GetClusterLevelWithTimeout(clientManagedDynamic, common.GvrCRD, "configs.config.gatekeeper.sh", true, defaultTimeoutSeconds)
 			Expect(configCRD).NotTo(BeNil())
-			cpsCRD := GetClusterLevelWithTimeout(clientManagedDynamic, gvrCRD, "constraintpodstatuses.status.gatekeeper.sh", true, defaultTimeoutSeconds)
+			cpsCRD := GetClusterLevelWithTimeout(clientManagedDynamic, common.GvrCRD, "constraintpodstatuses.status.gatekeeper.sh", true, defaultTimeoutSeconds)
 			Expect(cpsCRD).NotTo(BeNil())
-			ctpsCRD := GetClusterLevelWithTimeout(clientManagedDynamic, gvrCRD, "constrainttemplatepodstatuses.status.gatekeeper.sh", true, defaultTimeoutSeconds)
+			ctpsCRD := GetClusterLevelWithTimeout(clientManagedDynamic, common.GvrCRD, "constrainttemplatepodstatuses.status.gatekeeper.sh", true, defaultTimeoutSeconds)
 			Expect(ctpsCRD).NotTo(BeNil())
-			ctCRD := GetClusterLevelWithTimeout(clientManagedDynamic, gvrCRD, "constrainttemplates.templates.gatekeeper.sh", true, defaultTimeoutSeconds)
+			ctCRD := GetClusterLevelWithTimeout(clientManagedDynamic, common.GvrCRD, "constrainttemplates.templates.gatekeeper.sh", true, defaultTimeoutSeconds)
 			Expect(ctCRD).NotTo(BeNil())
 		})
 		It("configurationPolicies should be created on managed", func() {
 			By("Creating policy on hub")
 			utils.KubectlWithOutput("apply", "-f", GKPolicyYaml, "-n", "default", "--kubeconfig=../../kubeconfig_hub")
-			hubPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, GKPolicyName, "default", true, defaultTimeoutSeconds)
+			hubPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, GKPolicyName, "default", true, defaultTimeoutSeconds)
 			Expect(hubPlc).NotTo(BeNil())
 			By("Patching " + GKPolicyName + " pr with decision of cluster managed")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, "placement-"+GKPolicyName, "default", true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(clientHubDynamic, common.GvrPlacementRule, "placement-"+GKPolicyName, "default", true, defaultTimeoutSeconds)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace("default").UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(common.GvrPlacementRule).Namespace("default").UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
 			Expect(err).To(BeNil())
 			By("Checking configpolicies on managed")
-			krl := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, cfgpolKRLName, clusterNamespace, true, defaultTimeoutSeconds)
+			krl := utils.GetWithTimeout(clientManagedDynamic, common.GvrConfigurationPolicy, cfgpolKRLName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(krl).NotTo(BeNil())
-			audit := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, cfgpolauditName, clusterNamespace, true, defaultTimeoutSeconds)
+			audit := utils.GetWithTimeout(clientManagedDynamic, common.GvrConfigurationPolicy, cfgpolauditName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(audit).NotTo(BeNil())
-			admission := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, cfgpoladmissionName, clusterNamespace, true, defaultTimeoutSeconds)
+			admission := utils.GetWithTimeout(clientManagedDynamic, common.GvrConfigurationPolicy, cfgpoladmissionName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(admission).NotTo(BeNil())
 		})
 		It("K8sRequiredLabels ns-must-have-gk should be created on managed", func() {
 			By("Checking if K8sRequiredLabels CRD exists")
-			k8srequiredlabelsCRD := GetClusterLevelWithTimeout(clientManagedDynamic, gvrCRD, "k8srequiredlabels.constraints.gatekeeper.sh", true, defaultTimeoutSeconds*2)
+			k8srequiredlabelsCRD := GetClusterLevelWithTimeout(clientManagedDynamic, common.GvrCRD, "k8srequiredlabels.constraints.gatekeeper.sh", true, defaultTimeoutSeconds*2)
 			Expect(k8srequiredlabelsCRD).NotTo(BeNil())
 			By("Checking if ns-must-have-gk CR exists")
-			nsMustHaveGkCR := GetClusterLevelWithTimeout(clientManagedDynamic, gvrK8sRequiredLabels, "ns-must-have-gk", true, defaultTimeoutSeconds*2)
+			nsMustHaveGkCR := GetClusterLevelWithTimeout(clientManagedDynamic, common.GvrK8sRequiredLabels, "ns-must-have-gk", true, defaultTimeoutSeconds*2)
 			Expect(nsMustHaveGkCR).NotTo(BeNil())
 		})
 		It("K8sRequiredLabels ns-must-have-gk should be properly enforced for audit, no violation expected", func() {
 			By("Checking if ns-must-have-gk status field has been updated")
 			Eventually(func() interface{} {
-				nsMustHaveGkCR := GetClusterLevelWithTimeout(clientManagedDynamic, gvrK8sRequiredLabels, "ns-must-have-gk", true, defaultTimeoutSeconds)
+				nsMustHaveGkCR := GetClusterLevelWithTimeout(clientManagedDynamic, common.GvrK8sRequiredLabels, "ns-must-have-gk", true, defaultTimeoutSeconds)
 				return nsMustHaveGkCR.Object["status"]
 			}, defaultTimeoutSeconds, 1).ShouldNot(BeNil())
 			By("Checking if ns-must-have-gk status.totalViolations is equal to 0")
 			Eventually(func() interface{} {
-				nsMustHaveGkCR := GetClusterLevelWithTimeout(clientManagedDynamic, gvrK8sRequiredLabels, "ns-must-have-gk", true, defaultTimeoutSeconds)
+				nsMustHaveGkCR := GetClusterLevelWithTimeout(clientManagedDynamic, common.GvrK8sRequiredLabels, "ns-must-have-gk", true, defaultTimeoutSeconds)
 				return nsMustHaveGkCR.Object["status"].(map[string]interface{})["totalViolations"]
 			}, defaultTimeoutSeconds*2, 1).Should(Equal(int64(0)))
 			By("Checking if ns-must-have-gk status.violations field has been updated")
 			Eventually(func() interface{} {
-				nsMustHaveGkCR := GetClusterLevelWithTimeout(clientManagedDynamic, gvrK8sRequiredLabels, "ns-must-have-gk", true, defaultTimeoutSeconds)
+				nsMustHaveGkCR := GetClusterLevelWithTimeout(clientManagedDynamic, common.GvrK8sRequiredLabels, "ns-must-have-gk", true, defaultTimeoutSeconds)
 				fmt.Printf("%v\n", nsMustHaveGkCR.Object["status"].(map[string]interface{})["violations"])
 				return nsMustHaveGkCR.Object["status"].(map[string]interface{})["violations"]
 			}, defaultTimeoutSeconds*2, 1).Should(BeNil())
@@ -138,47 +139,47 @@ var _ = Describe("Test gatekeeper", func() {
 		It("K8sRequiredLabels ns-must-have-gk should be properly enforced for admission", func() {
 			By("Checking if ns-must-have-gk status.byPod field size is 3")
 			Eventually(func() interface{} {
-				nsMustHaveGkCR := GetClusterLevelWithTimeout(clientManagedDynamic, gvrK8sRequiredLabels, "ns-must-have-gk", true, defaultTimeoutSeconds)
+				nsMustHaveGkCR := GetClusterLevelWithTimeout(clientManagedDynamic, common.GvrK8sRequiredLabels, "ns-must-have-gk", true, defaultTimeoutSeconds)
 				return len(nsMustHaveGkCR.Object["status"].(map[string]interface{})["byPod"].([]interface{}))
 			}, defaultTimeoutSeconds*4, 1).Should(Equal(3))
 		})
 		It("should generate statuses properly on hub, no violation expected", func() {
 			By("Checking if status for policy template policy-gatekeeper-k8srequiredlabels is compliant")
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				return details[0].(map[string]interface{})["compliant"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 			By("Checking if violation message for policy template policy-gatekeeper-audit is compliant")
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				return details[1].(map[string]interface{})["compliant"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				return details[1].(map[string]interface{})["history"]
 			}, defaultTimeoutSeconds, 1).ShouldNot(BeNil())
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				Expect(details[1].(map[string]interface{})["history"]).NotTo(BeNil())
 				return details[1].(map[string]interface{})["history"].([]interface{})[0].(map[string]interface{})["message"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant; notification - k8srequiredlabels [ns-must-have-gk] found as specified, therefore this Object template is compliant"))
 			By("Checking if violation message for policy template policy-gatekeeper-admission is compliant")
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				return details[2].(map[string]interface{})["compliant"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				return details[2].(map[string]interface{})["history"]
 			}, defaultTimeoutSeconds, 1).ShouldNot(BeNil())
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				fmt.Printf("%v\n", details[2].(map[string]interface{})["history"].([]interface{})[0].(map[string]interface{})["message"])
 				return details[2].(map[string]interface{})["history"].([]interface{})[0].(map[string]interface{})["message"]
@@ -200,13 +201,13 @@ var _ = Describe("Test gatekeeper", func() {
 				ContainSubstring("ns-must-have-gk")))
 			By("Checking if status for policy template policy-gatekeeper-admission is noncompliant")
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				return details[2].(map[string]interface{})["compliant"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 			By("Checking if violation message for policy template policy-gatekeeper-admission is noncompliant")
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, "default."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				fmt.Printf("%v\n", details[2].(map[string]interface{})["history"].([]interface{})[0].(map[string]interface{})["message"])
 				return details[2].(map[string]interface{})["history"].([]interface{})[0].(map[string]interface{})["message"]
@@ -217,7 +218,7 @@ var _ = Describe("Test gatekeeper", func() {
 		It("should create relatedObjects properly on managed", func() {
 			By("Checking configurationpolicies on managed")
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, cfgpolauditName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientManagedDynamic, common.GvrConfigurationPolicy, cfgpolauditName, clusterNamespace, true, defaultTimeoutSeconds)
 				ro := plc.Object["status"].(map[string]interface{})["relatedObjects"].([]interface{})
 				return ro[0].(map[string]interface{})["object"].(map[string]interface{})["metadata"].(map[string]interface{})["name"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("ns-must-have-gk"))
@@ -228,10 +229,10 @@ var _ = Describe("Test gatekeeper", func() {
 			By("Deleting gatekeeper policy on hub")
 			utils.Kubectl("delete", "-f", GKPolicyYaml, "-n", "default", "--kubeconfig=../../kubeconfig_hub")
 			By("Checking if there is any policy left")
-			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
-			utils.ListWithTimeoutByNamespace(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, clusterNamespace, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientHubDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeoutByNamespace(clientManagedDynamic, common.GvrPolicy, metav1.ListOptions{}, clusterNamespace, 0, true, defaultTimeoutSeconds)
 			By("Checking if there is any configuration policy left")
-			utils.ListWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrConfigurationPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 			By("Deleting gatekeeper ConstraintTemplate and K8sRequiredLabels")
 			utils.Kubectl("delete", "K8sRequiredLabels", "--all", "--kubeconfig=../../kubeconfig_managed")
 			utils.Kubectl("delete", "crd", "k8srequiredlabels.constraints.gatekeeper.sh", "--kubeconfig=../../kubeconfig_managed")

--- a/test/e2e/iam_policy_test.go
+++ b/test/e2e/iam_policy_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/open-cluster-management/governance-policy-framework/test/common"
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,22 +20,22 @@ var _ = Describe("Test iam policy", func() {
 		It("should be created on managed cluster", func() {
 			By("Creating " + iamPolicyYaml)
 			utils.Kubectl("apply", "-f", iamPolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
-			hubPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, iamPolicyName, userNamespace, true, defaultTimeoutSeconds)
+			hubPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, iamPolicyName, userNamespace, true, defaultTimeoutSeconds)
 			Expect(hubPlc).NotTo(BeNil())
 			By("Patching " + iamPolicyName + "-plr with decision of cluster managed")
-			plr := utils.GetWithTimeout(clientHubDynamic, gvrPlacementRule, iamPolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
+			plr := utils.GetWithTimeout(clientHubDynamic, common.GvrPlacementRule, iamPolicyName+"-plr", userNamespace, true, defaultTimeoutSeconds)
 			plr.Object["status"] = utils.GeneratePlrStatus("managed")
-			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
+			_, err := clientHubDynamic.Resource(common.GvrPlacementRule).Namespace(userNamespace).UpdateStatus(context.TODO(), plr, metav1.UpdateOptions{})
 			Expect(err).To(BeNil())
 			By("Checking " + iamPolicyName + " on managed cluster in ns " + clusterNamespace)
-			managedplc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+iamPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+			managedplc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+iamPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(managedplc).NotTo(BeNil())
 		})
 		It("the policy should be compliant as there is no clusterrolebindings", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/iam_policy/" + iamPolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, iamPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, iamPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -44,7 +45,7 @@ var _ = Describe("Test iam policy", func() {
 			By("Checking if the status of root policy is noncompliant")
 			yamlPlc := utils.ParseYaml("../resources/iam_policy/" + iamPolicyName + "-noncompliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, iamPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, iamPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -54,7 +55,7 @@ var _ = Describe("Test iam policy", func() {
 			By("Checking if the status of root policy is compliant")
 			yamlPlc := utils.ParseYaml("../resources/iam_policy/" + iamPolicyName + "-compliant.yaml")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, iamPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, iamPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
@@ -62,10 +63,10 @@ var _ = Describe("Test iam policy", func() {
 			By("Deleting " + iamPolicyYaml)
 			utils.Kubectl("delete", "-f", iamPolicyYaml, "-n", userNamespace, "--kubeconfig=../../kubeconfig_hub")
 			By("Checking if there is any policy left")
-			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
-			utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientHubDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 			By("Checking if there is any iam policy left")
-			utils.ListWithTimeout(clientManagedDynamic, gvrIamPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+			utils.ListWithTimeout(clientManagedDynamic, common.GvrIamPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
 		})
 	})
 })

--- a/test/policy-collection/policy_collection_suite_test.go
+++ b/test/policy-collection/policy_collection_suite_test.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
@@ -31,12 +30,6 @@ var (
 	clientHubDynamic      dynamic.Interface
 	clientManaged         kubernetes.Interface
 	clientManagedDynamic  dynamic.Interface
-
-	gvrClusterVersion        = schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "clusterversions"}
-	gvrComplianceScan        = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancescans"}
-	gvrComplianceSuite       = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancesuites"}
-	gvrComplianceCheckResult = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancecheckresults"}
-	gvrPolicy                = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policies"}
 )
 
 func TestE2e(t *testing.T) {

--- a/test/policy-collection/policy_collection_suite_test.go
+++ b/test/policy-collection/policy_collection_suite_test.go
@@ -5,11 +5,6 @@ package e2e
 
 import (
 	"context"
-	"flag"
-	"fmt"
-	"os"
-	"os/user"
-	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -21,26 +16,27 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
+
+	"github.com/open-cluster-management/governance-policy-framework/test/common"
 )
 
 var (
-	userNamespace            string
-	clusterNamespace         string
-	clientHub                kubernetes.Interface
-	clientHubDynamic         dynamic.Interface
-	clientManaged            kubernetes.Interface
-	clientManagedDynamic     dynamic.Interface
-	gvrClusterVersion        schema.GroupVersionResource
-	gvrComplianceSuite       schema.GroupVersionResource
-	gvrComplianceScan        schema.GroupVersionResource
-	gvrComplianceCheckResult schema.GroupVersionResource
-	gvrPolicy                schema.GroupVersionResource
-	kubeconfigHub            string
-	kubeconfigManaged        string
-	defaultTimeoutSeconds    int
+	userNamespace         string
+	clusterNamespace      string
+	kubeconfigHub         string
+	kubeconfigManaged     string
+	defaultTimeoutSeconds int
+	clientHub             kubernetes.Interface
+	clientHubDynamic      dynamic.Interface
+	clientManaged         kubernetes.Interface
+	clientManagedDynamic  dynamic.Interface
+
+	gvrClusterVersion        = schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "clusterversions"}
+	gvrComplianceScan        = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancescans"}
+	gvrComplianceSuite       = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancesuites"}
+	gvrComplianceCheckResult = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancecheckresults"}
+	gvrPolicy                = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policies"}
 )
 
 func TestE2e(t *testing.T) {
@@ -52,25 +48,22 @@ func TestE2e(t *testing.T) {
 func init() {
 	klog.SetOutput(GinkgoWriter)
 	klog.InitFlags(nil)
-	flag.StringVar(&kubeconfigHub, "kubeconfig_hub", "../../kubeconfig_hub", "Location of the kubeconfig to use; defaults to KUBECONFIG if not set")
-	flag.StringVar(&kubeconfigManaged, "kubeconfig_managed", "../../kubeconfig_managed", "Location of the kubeconfig to use; defaults to KUBECONFIG if not set")
-	flag.StringVar(&userNamespace, "user_namespace", "policy-test", "ns on hub to create root policy")
-	flag.StringVar(&clusterNamespace, "cluster_namespace", "local-cluster", "cluster ns name")
-	flag.IntVar(&defaultTimeoutSeconds, "timeout_seconds", 30, "Timeout seconds for assertion")
 }
 
 var _ = BeforeSuite(func() {
 	By("Setup hub and managed client")
-	gvrClusterVersion = schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "clusterversions"}
-	gvrComplianceScan = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancescans"}
-	gvrComplianceSuite = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancesuites"}
-	gvrComplianceCheckResult = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancecheckresults"}
-	gvrPolicy = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policies"}
-	clientHub = NewKubeClient("", kubeconfigHub, "")
-	clientHubDynamic = NewKubeClientDynamic("", kubeconfigHub, "")
-	clientManaged = NewKubeClient("", kubeconfigManaged, "")
-	clientManagedDynamic = NewKubeClientDynamic("", kubeconfigManaged, "")
-	By("Create Namesapce if needed")
+	kubeconfigHub = common.KubeconfigHub
+	kubeconfigManaged = common.KubeconfigManaged
+	userNamespace = common.UserNamespace
+	clusterNamespace = common.ClusterNamespace
+	defaultTimeoutSeconds = common.DefaultTimeoutSeconds
+
+	clientHub = common.NewKubeClient("", kubeconfigHub, "")
+	clientHubDynamic = common.NewKubeClientDynamic("", kubeconfigHub, "")
+	clientManaged = common.NewKubeClient("", kubeconfigManaged, "")
+	clientManagedDynamic = common.NewKubeClientDynamic("", kubeconfigManaged, "")
+
+	By("Create Namespace if needed")
 	namespaces := clientHub.CoreV1().Namespaces()
 	if _, err := namespaces.Get(context.TODO(), userNamespace, metav1.GetOptions{}); err != nil && errors.IsNotFound(err) {
 		Expect(namespaces.Create(context.TODO(), &corev1.Namespace{
@@ -81,65 +74,3 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(namespaces.Get(context.TODO(), userNamespace, metav1.GetOptions{})).NotTo(BeNil())
 })
-
-func NewKubeClient(url, kubeconfig, context string) kubernetes.Interface {
-	klog.V(5).Infof("Create kubeclient for url %s using kubeconfig path %s\n", url, kubeconfig)
-	config, err := LoadConfig(url, kubeconfig, context)
-	if err != nil {
-		panic(err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		panic(err)
-	}
-
-	return clientset
-}
-
-func NewKubeClientDynamic(url, kubeconfig, context string) dynamic.Interface {
-	klog.V(5).Infof("Create kubeclient dynamic for url %s using kubeconfig path %s\n", url, kubeconfig)
-	config, err := LoadConfig(url, kubeconfig, context)
-	if err != nil {
-		panic(err)
-	}
-
-	clientset, err := dynamic.NewForConfig(config)
-	if err != nil {
-		panic(err)
-	}
-
-	return clientset
-}
-
-func LoadConfig(url, kubeconfig, context string) (*rest.Config, error) {
-	if kubeconfig == "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-	}
-	klog.V(5).Infof("Kubeconfig path %s\n", kubeconfig)
-	// If we have an explicit indication of where the kubernetes config lives, read that.
-	if kubeconfig != "" {
-		if context == "" {
-			return clientcmd.BuildConfigFromFlags(url, kubeconfig)
-		}
-		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
-			&clientcmd.ConfigOverrides{
-				CurrentContext: context,
-			}).ClientConfig()
-	}
-	// If not, try the in-cluster config.
-	if c, err := rest.InClusterConfig(); err == nil {
-		return c, nil
-	}
-	// If no in-cluster config, try the default location in the user's home directory.
-	if usr, err := user.Current(); err == nil {
-		klog.V(5).Infof("clientcmd.BuildConfigFromFlags for url %s using %s\n", url, filepath.Join(usr.HomeDir, ".kube", "config"))
-		if c, err := clientcmd.BuildConfigFromFlags("", filepath.Join(usr.HomeDir, ".kube", "config")); err == nil {
-			return c, nil
-		}
-	}
-
-	return nil, fmt.Errorf("could not create a valid kubeconfig")
-
-}

--- a/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/open-cluster-management/governance-policy-framework/test/common"
 	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/pkg/apis/policy/v1"
 	"github.com/open-cluster-management/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,18 +40,18 @@ var _ = Describe("RHACM4K-3055", func() {
 				"--type=json", "-p=[{\"op\": \"replace\", \"path\": \"/spec/clusterSelector/matchExpressions\", \"value\":[{\"key\": \"name\", \"operator\": \"In\", \"values\": ["+clusterNamespace+"]}]}]",
 				"--kubeconfig="+kubeconfigHub)
 			By("Checking policy-gatekeeper-operator on hub cluster in ns " + userNamespace)
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 			Expect(rootPlc).NotTo(BeNil())
 		})
 		It("stable/policy-gatekeeper-operator should be created on managed cluster", func() {
 			By("Checking policy-gatekeeper-operator on managed cluster in ns " + clusterNamespace)
-			managedplc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+			managedplc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 			Expect(managedplc).NotTo(BeNil())
 		})
 		It("stable/policy-gatekeeper-operator should be noncompliant", func() {
 			By("Checking if the status of root policy is noncompliant")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				var policy policiesv1.Policy
 				err := runtime.DefaultUnstructuredConverter.
 					FromUnstructured(rootPlc.UnstructuredContent(), &policy)
@@ -66,16 +67,16 @@ var _ = Describe("RHACM4K-3055", func() {
 		It("Enforcing stable/policy-gatekeeper-operator", func() {
 			Eventually(func() interface{} {
 				By("Patching remediationAction = enforce on root policy")
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-				clientHubDynamic.Resource(gvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+				clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
 				By("Checking if remediationAction is enforce for root policy")
-				rootPlc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc = utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("enforce"))
 			By("Checking if remediationAction is enforce for replicated policy")
 			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				return managedPlc.Object["spec"].(map[string]interface{})["remediationAction"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("enforce"))
 		})
@@ -148,7 +149,7 @@ var _ = Describe("RHACM4K-3055", func() {
 		It("stable/policy-gatekeeper-operator should be compliant", func() {
 			By("Checking if the status of root policy is compliant")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				var policy policiesv1.Policy
 				err := runtime.DefaultUnstructuredConverter.
 					FromUnstructured(rootPlc.UnstructuredContent(), &policy)
@@ -164,16 +165,16 @@ var _ = Describe("RHACM4K-3055", func() {
 		It("Informing stable/policy-gatekeeper-operator", func() {
 			Eventually(func() interface{} {
 				By("Patching remediationAction = inform on root policy")
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "inform"
-				clientHubDynamic.Resource(gvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+				clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
 				By("Checking if remediationAction is inform for root policy")
-				rootPlc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc = utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("inform"))
 			By("Checking if remediationAction is inform for replicated policy")
 			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				return managedPlc.Object["spec"].(map[string]interface{})["remediationAction"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("inform"))
 		})
@@ -189,13 +190,13 @@ var _ = Describe("RHACM4K-3055", func() {
 				"--type=json", "-p=[{\"op\": \"replace\", \"path\": \"/spec/clusterSelector/matchExpressions\", \"value\":[{\"key\": \"name\", \"operator\": \"In\", \"values\": ["+clusterNamespace+"]}]}]",
 				"--kubeconfig="+kubeconfigHub)
 			By("Checking policy-gatekeeper namespace on hub cluster in ns " + userNamespace)
-			rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, GKPolicyName, userNamespace, true, defaultTimeoutSeconds)
+			rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, GKPolicyName, userNamespace, true, defaultTimeoutSeconds)
 			Expect(rootPlc).NotTo(BeNil())
 		})
 		It("stable/policy-gatekeeper-sample should be compliant", func() {
 			By("Checking if the status of root policy is compliant")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, GKPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, GKPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				var policy policiesv1.Policy
 				err := runtime.DefaultUnstructuredConverter.
 					FromUnstructured(rootPlc.UnstructuredContent(), &policy)
@@ -209,7 +210,7 @@ var _ = Describe("RHACM4K-3055", func() {
 			}, defaultTimeoutSeconds*6, 1).Should(Equal(policiesv1.Compliant))
 			By("Checking if status for policy template policy-gatekeeper-audit is compliant")
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				return details[1].(map[string]interface{})["compliant"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
@@ -232,13 +233,13 @@ var _ = Describe("RHACM4K-3055", func() {
 				ContainSubstring("ns-must-have-gk")))
 			By("Checking if status for policy template policy-gatekeeper-admission is noncompliant")
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				return details[2].(map[string]interface{})["compliant"]
 			}, defaultTimeoutSeconds*2, 1).Should(Equal("NonCompliant"))
 			By("Checking if violation message for policy template policy-gatekeeper-admission is noncompliant")
 			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				fmt.Printf("%v\n", details[2].(map[string]interface{})["history"].([]interface{})[0].(map[string]interface{})["message"])
 				return details[2].(map[string]interface{})["history"].([]interface{})[0].(map[string]interface{})["message"]
@@ -249,7 +250,7 @@ var _ = Describe("RHACM4K-3055", func() {
 		It("stable/policy-gatekeeper-sample should be noncompliant", func() {
 			By("Checking if the status of root policy is noncompliant")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, GKPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, GKPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				var policy policiesv1.Policy
 				err := runtime.DefaultUnstructuredConverter.
 					FromUnstructured(rootPlc.UnstructuredContent(), &policy)
@@ -268,34 +269,34 @@ var _ = Describe("RHACM4K-3055", func() {
 		It("Enabling mutation feature through policy", func() {
 			Eventually(func() interface{} {
 				By("Patching mutatingWebhook = Enabled on root policy")
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				rootPlc.Object["spec"].(map[string]interface{})["policy-templates"].([]interface{})[1].(map[string]interface{})["objectDefinition"].(map[string]interface{})["spec"].(map[string]interface{})["object-templates"].([]interface{})[0].(map[string]interface{})["objectDefinition"].(map[string]interface{})["spec"].(map[string]interface{})["mutatingWebhook"] = "Enabled"
-				clientHubDynamic.Resource(gvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+				clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
 				By("Checking if mutatingWebhook is Enabled for root policy")
-				rootPlc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc = utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["spec"].(map[string]interface{})["policy-templates"].([]interface{})[1].(map[string]interface{})["objectDefinition"].(map[string]interface{})["spec"].(map[string]interface{})["object-templates"].([]interface{})[0].(map[string]interface{})["objectDefinition"].(map[string]interface{})["spec"].(map[string]interface{})["mutatingWebhook"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("Enabled"))
 		})
 		It("Enforcing policy-gatekeeper-operator to enable mutation feature", func() {
 			Eventually(func() interface{} {
 				By("Patching remediationAction = enforce on root policy")
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-				clientHubDynamic.Resource(gvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+				clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
 				By("Checking if remediationAction is enforce for root policy")
-				rootPlc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc = utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("enforce"))
 			By("Checking if remediationAction is enforce for replicated policy")
 			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				return managedPlc.Object["spec"].(map[string]interface{})["remediationAction"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("enforce"))
 		})
 		It("policy-gatekeeper-operator should be compliant", func() {
 			By("Checking if the status of root policy is compliant")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				var policy policiesv1.Policy
 				err := runtime.DefaultUnstructuredConverter.
 					FromUnstructured(rootPlc.UnstructuredContent(), &policy)
@@ -365,7 +366,7 @@ var _ = Describe("RHACM4K-3055", func() {
 		It(GKAssignPolicyName+" should be compliant", func() {
 			By("Checking if the status of root policy is compliant")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, GKAssignPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, GKAssignPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				var policy policiesv1.Policy
 				err := runtime.DefaultUnstructuredConverter.
 					FromUnstructured(rootPlc.UnstructuredContent(), &policy)
@@ -381,7 +382,7 @@ var _ = Describe("RHACM4K-3055", func() {
 		It(GKAssignMetadataPolicyName+" should be compliant", func() {
 			By("Checking if the status of root policy is compliant")
 			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, GKAssignMetadataPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, GKAssignMetadataPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				var policy policiesv1.Policy
 				err := runtime.DefaultUnstructuredConverter.
 					FromUnstructured(rootPlc.UnstructuredContent(), &policy)
@@ -421,11 +422,11 @@ var _ = Describe("RHACM4K-3055", func() {
 		It("Disabling mutation feature through policy", func() {
 			Eventually(func() interface{} {
 				By("Patching mutatingWebhook = Disabled on root policy")
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				rootPlc.Object["spec"].(map[string]interface{})["policy-templates"].([]interface{})[1].(map[string]interface{})["objectDefinition"].(map[string]interface{})["spec"].(map[string]interface{})["object-templates"].([]interface{})[0].(map[string]interface{})["objectDefinition"].(map[string]interface{})["spec"].(map[string]interface{})["mutatingWebhook"] = "Disabled"
-				clientHubDynamic.Resource(gvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+				clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
 				By("Checking if mutatingWebhook is Disabled for root policy")
-				rootPlc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc = utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["spec"].(map[string]interface{})["policy-templates"].([]interface{})[1].(map[string]interface{})["objectDefinition"].(map[string]interface{})["spec"].(map[string]interface{})["object-templates"].([]interface{})[0].(map[string]interface{})["objectDefinition"].(map[string]interface{})["spec"].(map[string]interface{})["mutatingWebhook"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("Disabled"))
 		})
@@ -460,16 +461,16 @@ var _ = Describe("RHACM4K-3055", func() {
 		It("Informing stable/policy-gatekeeper-operator", func() {
 			Eventually(func() interface{} {
 				By("Patching remediationAction = inform on root policy")
-				rootPlc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "inform"
-				clientHubDynamic.Resource(gvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
+				clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(context.TODO(), rootPlc, metav1.UpdateOptions{})
 				By("Checking if remediationAction is inform for root policy")
-				rootPlc = utils.GetWithTimeout(clientHubDynamic, gvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
+				rootPlc = utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, gatekeeperPolicyName, userNamespace, true, defaultTimeoutSeconds)
 				return rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("inform"))
 			By("Checking if remediationAction is inform for replicated policy")
 			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+				managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				return managedPlc.Object["spec"].(map[string]interface{})["remediationAction"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("inform"))
 		})
@@ -479,12 +480,12 @@ var _ = Describe("RHACM4K-3055", func() {
 		It("Clean up mutation policies", func() {
 			utils.KubectlWithOutput("delete", "-f", GKAssignMetadataPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
 			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+GKAssignMetadataPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
+				managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+GKAssignMetadataPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
 				return managedPlc
 			}, defaultTimeoutSeconds, 1).Should(BeNil())
 			utils.KubectlWithOutput("delete", "-f", GKAssignPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
 			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+GKAssignPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
+				managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+GKAssignPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
 				return managedPlc
 			}, defaultTimeoutSeconds, 1).Should(BeNil())
 			utils.KubectlWithOutput("delete", "-f", "../resources/gatekeeper/pod-mutation.yaml", "-n", "default", "--kubeconfig="+kubeconfigManaged)
@@ -493,7 +494,7 @@ var _ = Describe("RHACM4K-3055", func() {
 		It("Clean up stable/policy-gatekeeper-sample", func() {
 			utils.KubectlWithOutput("delete", "-f", GKPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
 			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
+				managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
 				return managedPlc
 			}, defaultTimeoutSeconds, 1).Should(BeNil())
 			utils.KubectlWithOutput("delete", "ns", "e2etestsuccess", "--kubeconfig="+kubeconfigManaged)
@@ -502,7 +503,7 @@ var _ = Describe("RHACM4K-3055", func() {
 		It("Clean up stable/policy-gatekeeper-operator", func() {
 			utils.KubectlWithOutput("delete", "-f", gatekeeperPolicyURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
 			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
+				managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
 				return managedPlc
 			}, defaultTimeoutSeconds, 1).Should(BeNil())
 			utils.Pause(20)


### PR DESCRIPTION
One interesting detail here is that the command line flags are parsed
by ginkgo at some unknown time. So the `clientHub` can't be defined in
the `common` package, or it would only ever use the default kubeconfig
settings.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>