### PR TITLE
Add metrics tests to run on canaries

### DIFF
--- a/build/run-test-image.sh
+++ b/build/run-test-image.sh
@@ -5,3 +5,4 @@
 set -e
 
 ginkgo -v --slowSpecThreshold=10 test/policy-collection -- -cluster_namespace=$MANAGED_CLUSTER_NAME
+ginkgo -v --slowSpecThreshold=10 test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package common
 
 import (

--- a/test/common/gvr.go
+++ b/test/common/gvr.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package common
 
 import "k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,4 +20,5 @@ var (
 	GvrComplianceScan        = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancescans"}
 	GvrComplianceSuite       = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancesuites"}
 	GvrComplianceCheckResult = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancecheckresults"}
+	GvrRoute                 = schema.GroupVersionResource{Group: "route.openshift.io", Version: "v1", Resource: "routes"}
 )

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -61,13 +61,13 @@ var _ = BeforeSuite(func() {
 	}
 
 	By("Create Namespace if needed")
-	namespaces := clientHub.CoreV1().Namespaces()
-	if _, err := namespaces.Get(context.TODO(), userNamespace, metav1.GetOptions{}); err != nil && errors.IsNotFound(err) {
-		Expect(namespaces.Create(context.TODO(), &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: userNamespace,
-			},
-		}, metav1.CreateOptions{})).NotTo(BeNil())
+	_, err := clientHub.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: userNamespace,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		Expect(errors.IsAlreadyExists(err)).Should(BeTrue())
 	}
-	Expect(namespaces.Get(context.TODO(), userNamespace, metav1.GetOptions{})).NotTo(BeNil())
+	Expect(clientHub.CoreV1().Namespaces().Get(context.TODO(), userNamespace, metav1.GetOptions{})).NotTo(BeNil())
 })

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -1,0 +1,73 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+
+	"github.com/open-cluster-management/governance-policy-framework/test/common"
+)
+
+var (
+	userNamespace         string
+	clusterNamespace      string
+	kubeconfigHub         string
+	kubeconfigManaged     string
+	defaultTimeoutSeconds int
+	clientHub             kubernetes.Interface
+	clientHubDynamic      dynamic.Interface
+	clientManaged         kubernetes.Interface
+	clientManagedDynamic  dynamic.Interface
+	getComplianceState    func(policyName string) func() interface{}
+)
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../test-output/integration.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Policy Framework repo integration Suite", []Reporter{junitReporter})
+}
+
+func init() {
+	klog.SetOutput(GinkgoWriter)
+	klog.InitFlags(nil)
+}
+
+var _ = BeforeSuite(func() {
+	By("Setup hub and managed client")
+	kubeconfigHub = common.KubeconfigHub
+	kubeconfigManaged = common.KubeconfigManaged
+	userNamespace = common.UserNamespace
+	clusterNamespace = common.ClusterNamespace
+	defaultTimeoutSeconds = common.DefaultTimeoutSeconds
+
+	clientHub = common.NewKubeClient("", kubeconfigHub, "")
+	clientHubDynamic = common.NewKubeClientDynamic("", kubeconfigHub, "")
+	clientManaged = common.NewKubeClient("", kubeconfigManaged, "")
+	clientManagedDynamic = common.NewKubeClientDynamic("", kubeconfigManaged, "")
+
+	getComplianceState = func(policyName string) func() interface{} {
+		return common.GetComplianceState(clientHubDynamic, userNamespace, policyName, clusterNamespace)
+	}
+
+	By("Create Namespace if needed")
+	namespaces := clientHub.CoreV1().Namespaces()
+	if _, err := namespaces.Get(context.TODO(), userNamespace, metav1.GetOptions{}); err != nil && errors.IsNotFound(err) {
+		Expect(namespaces.Create(context.TODO(), &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: userNamespace,
+			},
+		}, metav1.CreateOptions{})).NotTo(BeNil())
+	}
+	Expect(namespaces.Get(context.TODO(), userNamespace, metav1.GetOptions{})).NotTo(BeNil())
+})

--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -74,6 +74,10 @@ var _ = Describe("Test policy_governance_info metric", func() {
 		}, defaultTimeoutSeconds, 1).Should(ContainSubstring("Unauthorized"))
 	})
 	It("Checks that endpoint has a HELP comment for the metric", func() {
+		By("Creating a policy")
+		oc("apply", "-f", compliantPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
+		// Don't need to check compliance - just need to guarantee there is a policy in the cluster
+
 		token, err := oc("whoami", "-t")
 		Expect(err).To(BeNil())
 		Eventually(func() interface{} {

--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -31,7 +31,7 @@ const (
 	noncompliantPolicyName    = "policy-metric-noncompliant"
 )
 
-var routeURL string
+var routeHost string
 
 var _ = Describe("Test policy_governance_info metric", func() {
 	It("Sets up the metrics service endpoint for tests", func() {
@@ -67,8 +67,8 @@ var _ = Describe("Test policy_governance_info metric", func() {
 			}, defaultTimeoutSeconds, 1).Should(Equal(1))
 		}
 
-		routeURL = routeList.Items[0].Object["spec"].(map[string]interface{})["host"].(string)
-		By("Got the metrics route url: " + routeURL)
+		routeHost = routeList.Items[0].Object["spec"].(map[string]interface{})["host"].(string)
+		By("Got the metrics route url: " + routeHost)
 	})
 	It("Checks that the endpoint does not expose metrics without auth", func() {
 		Eventually(func() interface{} {
@@ -160,11 +160,11 @@ func getMetricsFromRoute(authToken string) (body, status string, err error) {
 		},
 		Timeout: 5 * time.Second,
 	}
-	req, err := http.NewRequest("GET", "https://"+routeURL+"/metrics", nil)
+	req, err := http.NewRequest("GET", "https://"+routeHost+"/metrics", nil)
 	if err != nil {
 		return "", "", err
 	}
-	if len(authToken) > 0 {
+	if authToken != "" {
 		req.Header.Add("Authorization", "Bearer "+authToken)
 	}
 	resp, err := client.Do(req)

--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -1,0 +1,149 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/open-cluster-management/governance-policy-framework/test/common"
+	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/pkg/apis/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	propagatorMetricsSelector = "component=ocm-policy-propagator"
+	ocmNS                     = "open-cluster-management"
+	metricName                = "policy_governance_info"
+	compliantPolicyYaml       = "../resources/policy_info_metric/compliant.yaml"
+	compliantPolicyName       = "policy-metric-compliant"
+	noncompliantPolicyYaml    = "../resources/policy_info_metric/noncompliant.yaml"
+	noncompliantPolicyName    = "policy-metric-noncompliant"
+)
+
+var routeURL string
+
+var _ = Describe("Test policy_governance_info metric", func() {
+	It("Sets up the metrics service endpoint for tests", func() {
+		By("Ensuring the metrics service exists")
+		svcList, err := clientHub.CoreV1().Services(ocmNS).List(context.TODO(), metav1.ListOptions{LabelSelector: propagatorMetricsSelector})
+		Expect(err).To(BeNil())
+		Expect(len(svcList.Items)).To(Equal(1))
+		metricsSvc := svcList.Items[0]
+
+		By("Checking for an existing metrics route")
+		var routeList *unstructured.UnstructuredList
+		Eventually(func() interface{} {
+			var err error
+			routeList, err = clientHubDynamic.Resource(common.GvrRoute).Namespace(ocmNS).List(context.TODO(), metav1.ListOptions{LabelSelector: propagatorMetricsSelector})
+			if err != nil {
+				return err
+			}
+			return len(routeList.Items)
+		}, defaultTimeoutSeconds, 1).Should(Or(Equal(0), Equal(1)))
+
+		if len(routeList.Items) == 0 {
+			By("Exposing the metrics service as a route")
+			_, err = oc("expose", "service", metricsSvc.Name, "-n", ocmNS, `--overrides={"spec":{"tls":{"termination":"reencrypt"}}}`)
+			Expect(err).To(BeNil())
+
+			Eventually(func() interface{} {
+				var err error
+				routeList, err = clientHubDynamic.Resource(common.GvrRoute).Namespace(ocmNS).List(context.TODO(), metav1.ListOptions{LabelSelector: propagatorMetricsSelector})
+				if err != nil {
+					return err
+				}
+				return len(routeList.Items)
+			}, defaultTimeoutSeconds, 1).Should(Equal(1))
+		}
+
+		routeURL = routeList.Items[0].Object["spec"].(map[string]interface{})["host"].(string)
+		By("Got the metrics route url: " + routeURL)
+	})
+	It("Checks that the endpoint does not expose metrics without auth", func() {
+		Eventually(func() interface{} {
+			resp, err := curlMetricsRoute()
+			if err != nil {
+				return err
+			}
+			return resp
+		}, defaultTimeoutSeconds, 1).Should(ContainSubstring("Unauthorized"))
+	})
+	It("Checks that endpoint has a HELP comment for the metric", func() {
+		token, err := oc("whoami", "-t")
+		Expect(err).To(BeNil())
+		Eventually(func() interface{} {
+			resp, err := curlMetricsRoute("--header", "Authorization: Bearer "+token)
+			if err != nil {
+				return err
+			}
+			return resp
+		}, defaultTimeoutSeconds, 1).Should(ContainSubstring("HELP " + metricName))
+	})
+	It("Checks that a compliant policy reports a metric of 0", func() {
+		By("Creating a compliant policy")
+		oc("apply", "-f", compliantPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
+		Eventually(
+			getComplianceState(compliantPolicyName),
+			defaultTimeoutSeconds,
+			1,
+		).Should(Equal(policiesv1.Compliant))
+
+		By("Checking the policy metric")
+		token, err := oc("whoami", "-t")
+		Expect(err).To(BeNil())
+		regex := `(?m)` + metricName + `{.*policy="` + compliantPolicyName + `.*} 0$`
+		Eventually(func() interface{} {
+			resp, err := curlMetricsRoute("--header", "Authorization: Bearer "+token)
+			if err != nil {
+				return err
+			}
+			return resp
+		}, defaultTimeoutSeconds, 1).Should(MatchRegexp(regex))
+	})
+	It("Checks that a noncompliant policy reports a metric of 1", func() {
+		By("Creating a noncompliant policy")
+		oc("apply", "-f", noncompliantPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
+		Eventually(
+			getComplianceState(noncompliantPolicyName),
+			defaultTimeoutSeconds,
+			1,
+		).Should(Equal(policiesv1.NonCompliant))
+
+		By("Checking the policy metric")
+		token, err := oc("whoami", "-t")
+		Expect(err).To(BeNil())
+		regex := `(?m)` + metricName + `{.*policy="` + noncompliantPolicyName + `.*} 1$`
+		Eventually(func() interface{} {
+			resp, err := curlMetricsRoute("--header", "Authorization: Bearer "+token)
+			if err != nil {
+				return err
+			}
+			return resp
+		}, defaultTimeoutSeconds, 1).Should(MatchRegexp(regex))
+	})
+	It("Cleans up", func() {
+		oc("delete", "-f", compliantPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
+		oc("delete", "-f", noncompliantPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
+		oc("delete", "route", "-n", ocmNS, "-l", propagatorMetricsSelector)
+	})
+})
+
+func oc(args ...string) (string, error) {
+	output, err := exec.Command("oc", args...).CombinedOutput()
+	if len(args) > 0 && args[0] != "whoami" {
+		fmt.Println(string(output))
+	}
+	return string(output), err
+}
+
+func curlMetricsRoute(args ...string) (string, error) {
+	argList := []string{"-k", "https://" + routeURL + "/metrics"}
+	argList = append(argList, args...)
+	output, err := exec.Command("curl", argList...).CombinedOutput()
+	return string(output), err
+}

--- a/test/resources/policy_info_metric/compliant.yaml
+++ b/test/resources/policy_info_metric/compliant.yaml
@@ -1,0 +1,52 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-metric-compliant
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-metric-compliant-policy-ns
+        spec:
+          remediationAction: enforce
+          severity: low
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Namespace
+                apiVersion: v1
+                metadata:
+                  name: policy-metric-test-compliant
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-metric-compliant
+placementRef:
+  name: placement-policy-metric-compliant
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: policy-metric-compliant
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-metric-compliant
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions: []

--- a/test/resources/policy_info_metric/noncompliant.yaml
+++ b/test/resources/policy_info_metric/noncompliant.yaml
@@ -1,0 +1,52 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-metric-noncompliant
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-metric-noncompliant-policy-ns
+        spec:
+          remediationAction: inform
+          severity: low
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Namespace
+                apiVersion: v1
+                metadata:
+                  name: policy-metric-test-noncompliant
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-metric-noncompliant
+placementRef:
+  name: placement-policy-metric-noncompliant
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: policy-metric-noncompliant
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-metric-noncompliant
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions: []


### PR DESCRIPTION
The tests in the propagator itself verifies some of these same things,
but the tests here use the service and rbac-proxy set up in the Helm
chart, to verify they are working as expected. One additional test is
to verify that the metrics can't be seen by unauthorized users.

This utilizes the `oc` cli's ability to expose services as a route, so
that we can curl directly to the metrics endpoint. One alternative that
I considered was using a port-forward, but that was difficult to manage.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/14992

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>