### PR TITLE
Use ioutil.ReadAll instead of io.ReadAll

### DIFF
--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"os/exec"
 	"strings"
@@ -172,7 +172,7 @@ func getMetricsFromRoute(authToken string) (body, status string, err error) {
 		return "", "", err
 	}
 	defer resp.Body.Close()
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	return string(bodyBytes), resp.Status, err
 }
 


### PR DESCRIPTION
The `io.ReadAll` function was added in Go version 1.16, so depending
on the version used by test runners, the tests might fail to compile.
The `ioutil.ReadAll` function still exists and can be used for
compatability.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>

Since Go 1.17 just came out, we will need to bump up versions in our go.mod and test runners (we currently use 1.14), but that is a separate issue. This will fix the e2e tests with minimal changes.