### PR TITLE
Disable new metrics test

### DIFF
--- a/build/run-test-image.sh
+++ b/build/run-test-image.sh
@@ -5,4 +5,3 @@
 set -e
 
 ginkgo -v --slowSpecThreshold=10 test/policy-collection -- -cluster_namespace=$MANAGED_CLUSTER_NAME
-ginkgo -v --slowSpecThreshold=10 test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME


### PR DESCRIPTION
It is failing on the e2e clusters, partly because some of the tests are
not using the right kubeconfig, but also because the e2e clusters do not
use the updated deployment with the rbac proxy and service endpoint that
this suite would test.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>