### PR TITLE
Disable metrics tests from canaries

### DIFF
--- a/build/run-test-image.sh
+++ b/build/run-test-image.sh
@@ -5,4 +5,3 @@
 set -e
 
 ginkgo -v --slowSpecThreshold=10 test/policy-collection -- -cluster_namespace=$MANAGED_CLUSTER_NAME
-ginkgo -v --slowSpecThreshold=10 test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME


### PR DESCRIPTION
They were working on the grc e2e cluster / periodic tests, but failing
in the canary. The `oc whoami -t` command seems to fail in that env,
but that token is needed for auth with the metrics rbac proxy.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>