### PR TITLE
Add metadata for the canary tests to be identifed by CICD

### DIFF
--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -31,7 +31,7 @@ var propagatorMetricsURL string
 
 var token string
 
-var _ = Describe("Test policy_governance_info metric", func() {
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric", func() {
 	It("Sets up the metrics service endpoint for tests", func() {
 		By("Ensuring the metrics service exists")
 		svcList, err := clientHub.CoreV1().Services(ocmNS).List(context.TODO(), metav1.ListOptions{LabelSelector: propagatorMetricsSelector})

--- a/test/policy-collection/policy_iam_test.go
+++ b/test/policy-collection/policy_iam_test.go
@@ -18,7 +18,7 @@ const iamPolicyURL = "https://raw.githubusercontent.com/open-cluster-management/
 const iamPolicyManagedNamespace = "iam-policy-test"
 
 // Note that these tests must be run on OpenShift since the tests create an OpenShift group
-var _ = Describe("Test the stable IAM policy", func() {
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the stable IAM policy", func() {
 	var getIAMComplianceState func() interface{}
 	BeforeEach(func() {
 		// Assign this here to avoid using nil pointers as arguments


### PR DESCRIPTION
This is required by the CICD team. See the following comment for
context:
https://github.com/open-cluster-management/backlog/issues/15560#issuecomment-911875009