### PR TITLE
Increase compliance operator pod timeout

### DIFF
--- a/test/policy-collection/policy_comp_operator_test.go
+++ b/test/policy-collection/policy_comp_operator_test.go
@@ -215,7 +215,7 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] Test compliance opera
 				podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{LabelSelector: "profile-bundle=ocp4"})
 				Expect(err).To(BeNil())
 				return len(podList.Items)
-			}, defaultTimeoutSeconds*4, 1).Should(Equal(1))
+			}, defaultTimeoutSeconds*6, 1).Should(Equal(1))
 			By("Checking if pod ocp4-pp is running")
 			Eventually(func() interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{LabelSelector: "profile-bundle=ocp4"})
@@ -227,7 +227,7 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] Test compliance opera
 				podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{LabelSelector: "profile-bundle=rhcos4"})
 				Expect(err).To(BeNil())
 				return len(podList.Items)
-			}, defaultTimeoutSeconds*4, 1).Should(Equal(1))
+			}, defaultTimeoutSeconds*6, 1).Should(Equal(1))
 			By("Checking if pod rhcos4-pp is running")
 			Eventually(func() interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{LabelSelector: "profile-bundle=rhcos4"})


### PR DESCRIPTION
Not sure if this will fix it, but I'm hoping so. I watched the compliance operator pods during a run, and they all seemed to come up okay.
```
$ oc get pods -n openshift-compliance
NAME                                                              READY   STATUS     RESTARTS   AGE
compliance-operator-8c9bc7466-pxkmc                               1/1     Running    1          4m7s
ocp4-e8-api-checks-pod                                            0/2     Init:0/2   0          2s
ocp4-e8-rs-7b5f58f497-zrg92                                       0/1     Pending    0          2s
ocp4-openshift-compliance-pp-6d7c7db4bd-nx679                     1/1     Running    0          98s
rhcos4-e8-master-ip-10-0-132-93.us-east-2.compute.internal-pod    0/2     Init:0/1   0          2s
rhcos4-e8-master-ip-10-0-166-179.us-east-2.compute.internal-pod   0/2     Init:0/1   0          2s
rhcos4-e8-master-ip-10-0-192-237.us-east-2.compute.internal-pod   0/2     Init:0/1   0          2s
rhcos4-e8-master-rs-575fc5c979-kcfjv                              0/1     Pending    0          2s
rhcos4-e8-worker-ip-10-0-132-93.us-east-2.compute.internal-pod    0/2     Init:0/1   0          2s
rhcos4-e8-worker-ip-10-0-166-179.us-east-2.compute.internal-pod   0/2     Init:0/1   0          2s
rhcos4-e8-worker-ip-10-0-192-237.us-east-2.compute.internal-pod   0/2     Init:0/1   0          1s
rhcos4-e8-worker-rs-6b64854bc-xgq8t                               0/1     Pending    0          2s
rhcos4-openshift-compliance-pp-c7b548bd-pj7w6                     1/1     Running    0          98s
```

Specifically, the command that is failing in the tests also seems to work when run manually:
```
$ oc get pods -n openshift-compliance -l profile-bundle=ocp4
NAME                                            READY   STATUS    RESTARTS   AGE
ocp4-openshift-compliance-pp-6d7c7db4bd-nx679   1/1     Running   0          2m12s
```