### PR TITLE
Fix token fetch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,13 @@ e2e-test:
 		ginkgo -v --slowSpecThreshold=10 --regexScansFilePath=true --focus=$(TEST_FILE) test/e2e;\
 	fi
 
+integration-test:
+	@if [ -z "$(TEST_FILE)" ]; then\
+		ginkgo -v --slowSpecThreshold=10 test/integration;\
+	else\
+		ginkgo -v --slowSpecThreshold=10 --regexScansFilePath=true --focus=$(TEST_FILE) test/integration;\
+	fi
+
 policy-collection-test:
 	@if [ -z "$(TEST_FILE)" ]; then\
 		ginkgo -v --slowSpecThreshold=10 test/policy-collection;\

--- a/doc/development.md
+++ b/doc/development.md
@@ -66,6 +66,13 @@ export TEST_FILE=<filename_test.go>
 make e2e-test
 ```
 
+### Integration
+
+```shell
+make integration-test
+```
+
+
 ### Policy Collection
 
 ```shell

--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -157,5 +157,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 		common.OcHub("delete", "route", "-n", ocmNS, "-l", propagatorMetricsSelector)
 		common.OcHub("delete", "clusterrolebinding", roleBindingName)
 		common.OcHub("delete", "serviceaccount", saName, "-n", userNamespace)
+		common.OcHub("delete", "namespace", userNamespace)
+		common.OcHub("delete", "namespace", "policy-metric-test-compliant")
 	})
 })


### PR DESCRIPTION
The secret name had single quotes (`'`) around it, (I think) causing subsequent commands to fail. This removes the quotes and also adds logic to not print any output from secrets (though maybe this is too broad).