### PR TITLE
increase timeout for metric availability

### DIFF
--- a/test/integration/policy_report_metric_test.go
+++ b/test/integration/policy_report_metric_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Test policyreport_info metric", func() {
 				return err
 			}
 			return resp
-		}, 120, 1).Should(common.MatchMetricValue(insightsMetricName, policyLabel, "1"))
+		}, defaultTimeoutSeconds*5, 1).Should(common.MatchMetricValue(insightsMetricName, policyLabel, "1"))
 	})
 	It("Checks that changing the policy to compliant removes the metric", func() {
 		By("Creating a compliant policy")


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

canary failures seem to be because the poll interval change isn't being applied quickly enough so the metric takes longer than expected to show up