### PR TITLE
merge two test suites into single ginkgo run

### DIFF
--- a/build/run-test-image.sh
+++ b/build/run-test-image.sh
@@ -4,5 +4,4 @@
 
 set -e
 
-ginkgo -v --slowSpecThreshold=10 test/policy-collection -- -cluster_namespace=$MANAGED_CLUSTER_NAME
-ginkgo -v --slowSpecThreshold=10 test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME
+ginkgo -v --slowSpecThreshold=10 test/policy-collection test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME


### PR DESCRIPTION
Signed-off-by: Yu Cao <ycao@redhat.com>

I noticed if the policy-collection test suite has failures, the integration test suite would be skipped. see https://app.travis-ci.com/github/open-cluster-management/governance-policy-framework/jobs/539861128#L2447
This might help.