### PR TITLE
Increase a timeout in the policy generator test

### DIFF
--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -105,7 +105,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator in an Ap
 				)
 				return err
 			},
-			defaultTimeoutSeconds*2,
+			defaultTimeoutSeconds*4,
 			1,
 		).Should(BeNil())
 		// Delete the kubeconfig file after the test.


### PR DESCRIPTION
It seems that sometimes logging in as the new user isn't ready after the
current timeout. Occasionally, it'll fail with a 401 HTTP status code.
This doubles that timeout in the hopes of making this test more stable.

Here is an example of a passing and failing canary run:
https://app.travis-ci.com/github/open-cluster-management/canary/jobs/539930135
https://app.travis-ci.com/github/open-cluster-management/canary/jobs/539991005