### PR TITLE
Increase the timeout for the login in the policy generator test

### DIFF
--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -96,6 +96,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator in an Ap
 		hubServerURL = strings.TrimSuffix(hubServerURL, "\n")
 		// Use eventually since it can take a while for OpenShift to configure itself with the new
 		// identity provider (IDP).
+		const fiveMinutes = 5 * 60
 		var kubeconfigSubAdmin string
 		Eventually(
 			func() error {
@@ -105,7 +106,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator in an Ap
 				)
 				return err
 			},
-			defaultTimeoutSeconds*4,
+			fiveMinutes,
 			1,
 		).Should(BeNil())
 		// Delete the kubeconfig file after the test.


### PR DESCRIPTION
This sets the timeout to five minutes from two minutes. Locally, against
an OCP cluster, this usually takes about 15 seconds, but on some
clusters, this can take longer.

In essence, we are waiting for the cluster authentication operator to
notice the IDP configuration change and modify the oauth-openshift
deployment in order to restart the pods.