### PR TITLE
increase time out to 5 mins

### DIFF
--- a/test/policy-collection/policy_iam_test.go
+++ b/test/policy-collection/policy_iam_test.go
@@ -53,7 +53,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the stable IAM policy", func(
 
 	It("stable/"+iamPolicyName+" should be compliant", func() {
 		By("Checking if the status of the root policy is compliant")
-		Eventually(getIAMComplianceState, defaultTimeoutSeconds*2, 1).Should(Equal(policiesv1.Compliant))
+		Eventually(getIAMComplianceState, defaultTimeoutSeconds*10, 1).Should(Equal(policiesv1.Compliant))
 	})
 
 	It("Make the policy noncompliant", func() {
@@ -93,7 +93,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the stable IAM policy", func(
 
 	It("stable/"+iamPolicyName+" should be compliant", func() {
 		By("Checking if the status of the root policy is compliant")
-		Eventually(getIAMComplianceState, defaultTimeoutSeconds*2, 1).Should(Equal(policiesv1.Compliant))
+		Eventually(getIAMComplianceState, defaultTimeoutSeconds*10, 1).Should(Equal(policiesv1.Compliant))
 	})
 
 	It("Clean up stable/"+iamPolicyName, func() {

--- a/test/policy-collection/policy_iam_test.go
+++ b/test/policy-collection/policy_iam_test.go
@@ -53,6 +53,8 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the stable IAM policy", func(
 
 	It("stable/"+iamPolicyName+" should be compliant", func() {
 		By("Checking if the status of the root policy is compliant")
+		// Increasing the time out for now to wait for the iam policy test from GRC-UI to complete.
+		// iam policy test from GRC-UI takes around 5 minutes to complete.
 		Eventually(getIAMComplianceState, defaultTimeoutSeconds*10, 1).Should(Equal(policiesv1.Compliant))
 	})
 
@@ -93,6 +95,8 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the stable IAM policy", func(
 
 	It("stable/"+iamPolicyName+" should be compliant", func() {
 		By("Checking if the status of the root policy is compliant")
+		// Increasing the time out for now to wait for the iam policy test from GRC-UI to complete.
+		// iam policy test from GRC-UI takes around 5 minutes to complete.
 		Eventually(getIAMComplianceState, defaultTimeoutSeconds*10, 1).Should(Equal(policiesv1.Compliant))
 	})
 


### PR DESCRIPTION
Signed-off-by: Yu Cao <ycao@redhat.com>

Canary failure: https://github.com/open-cluster-management/backlog/issues/16600
GRC integration test failure: https://app.travis-ci.com/github/open-cluster-management/governance-policy-framework/jobs/540596633#L2473-L2477
Still need to figure out the long term solution for test collision. 

Increasing the time out for now to wait for the iam policy test from GRC-UI to complete. iam policy test from GRC-UI takes around 5 minutes to complete. see https://app.travis-ci.com/github/open-cluster-management/canary/jobs/540539004#L839
Once completed, it should clean up the clusterrolebinding thus this test should pass.
