### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile.e2etest
+++ b/Dockerfile.e2etest
@@ -1,8 +1,9 @@
 # Copyright (c) 2020 Red Hat, Inc.
 
-# Stage 1: Use image builder to build the target binaries
-FROM registry.ci.openshift.org/open-cluster-management/builder:go1.16-linux AS builder
+# Stage 1: Use image builder to retrieve Go binaries
+FROM golang:1.16 AS builder
 
+# Stage 2: Copy Go binaries and run tests on ubi-minimal
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 RUN  microdnf update -y \


### PR DESCRIPTION
In the process of moving to Prow, it's probably wise to use the community image like we do in other repos and then we'll overwrite this with the CICD builder image in Prow.