### PR TITLE
Increase time out for gatekeeper admission

### DIFF
--- a/test/e2e/gatekeeper_test.go
+++ b/test/e2e/gatekeeper_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Test gatekeeper", func() {
 			Eventually(func() interface{} {
 				nsMustHaveGkCR := GetClusterLevelWithTimeout(clientManagedDynamic, common.GvrK8sRequiredLabels, "ns-must-have-gk", true, defaultTimeoutSeconds)
 				return len(nsMustHaveGkCR.Object["status"].(map[string]interface{})["byPod"].([]interface{}))
-			}, defaultTimeoutSeconds*4, 1).Should(Equal(3))
+			}, defaultTimeoutSeconds*8, 1).Should(Equal(3))
 		})
 		It("should generate statuses properly on hub, no violation expected", func() {
 			By("Checking if status for policy template policy-gatekeeper-k8srequiredlabels is compliant")


### PR DESCRIPTION
Signed-off-by: Yu Cao <ycao@redhat.com>

This should address the flakiness of gatekeeper e2e test for grc pipeline
https://app.travis-ci.com/github/open-cluster-management/governance-policy-framework/builds/239542715