### PR TITLE
make metric timeout for compliant policy the same as noncompliant

### DIFF
--- a/test/integration/policy_report_metric_test.go
+++ b/test/integration/policy_report_metric_test.go
@@ -175,7 +175,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", fu
 				return err
 			}
 			return resp
-		}, defaultTimeoutSeconds*2, 1).ShouldNot(common.MatchMetricValue(insightsMetricName, policyLabel, "1"))
+		}, defaultTimeoutSeconds*8, 1).ShouldNot(common.MatchMetricValue(insightsMetricName, policyLabel, "1"))
 	})
 	It("Cleans up", func() {
 		//unset poll interval


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

https://github.com/open-cluster-management/backlog/issues/17260

previously, the poll interval to reset the metric was 1 minute and the timeout was also 1 minute, so there could occasionally be failures if the metric took too long to update. this PR makes the metric timeout the same as the timeout for the noncompliant metric to make the test more stable.