### PR TITLE
double policy timeout in policyreport test

### DIFF
--- a/test/integration/policy_report_metric_test.go
+++ b/test/integration/policy_report_metric_test.go
@@ -144,7 +144,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", fu
 		common.OcHub("apply", "-f", noncompliantPolicyYamlReport, "-n", userNamespace)
 		Eventually(
 			getComplianceState(noncompliantPolicyNameReport),
-			defaultTimeoutSeconds*2,
+			defaultTimeoutSeconds*4,
 			1,
 		).Should(Equal(policiesv1.NonCompliant))
 
@@ -175,7 +175,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", fu
 		common.OcHub("apply", "-f", compliantPolicyYamlReport, "-n", userNamespace)
 		Eventually(
 			getComplianceState(compliantPolicyNameReport),
-			defaultTimeoutSeconds*2,
+			defaultTimeoutSeconds*4,
 			1,
 		).Should(Equal(policiesv1.Compliant))
 


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

https://github.com/open-cluster-management/backlog/issues/17450

logs for the configurationpolicy controller for this test showed
```
{"level":"error","ts":1634762888.972851,"logger":"configuration-policy-controller","msg":"Operation cannot be fulfilled on configurationpolicies.policy.open-cluster-management.io \"policyreport-metric-noncompliant-policy-ns\": the object has been modified; please apply your changes to the latest version and try again","error":"Operation cannot be fulfilled on configurationpolicies.policy.open-cluster-management.io \"policyreport-metric-noncompliant-policy-ns\": the object has been modified; please apply your changes to the latest version and try again","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/remote-source/deps/gomod/pkg/mod/github.com/go-logr/zapr@v0.4.0/zapr.go:132\ngithub.com/open-cluster-management/config-policy-controller/pkg/controller/configurationpolicy.addForUpdate\n\t/remote-source/app/pkg/controller/configurationpolicy/configurationpolicy_controller.go:1606\ngithub.com/open-cluster-management/config-policy-controller/pkg/controller/configurationpolicy.checkRelatedAndUpdate\n\t/remote-source/app/pkg/controller/configurationpolicy/configurationpolicy_controller.go:459\ngithub.com/open-cluster-management/config-policy-controller/pkg/controller/configurationpolicy.handleObjectTemplates\n\t/remote-source/app/pkg/controller/configurationpolicy/configurationpolicy_controller.go:451\ngithub.com/open-cluster-management/config-policy-controller/pkg/controller/configurationpolicy.PeriodicallyExecConfigPolicies\n\t/remote-source/app/pkg/controller/configurationpolicy/configurationpolicy_controller.go:243"}
```
which implies that the patch to change the policy to `mustnothave` occurred at the same time the controller was trying to apply the status for the policy. Doubling the policy timeout should help to avoid this.