### PR TITLE
Send travis notifications to a webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,4 +120,6 @@ notifications:
       - "Build details: %{build_url}"
     on_success: always
     on_failure: always
-    
+  webhooks:
+    urls:
+      - secure: "jiUa9BJ6QbUdkXhFIf3JxxUOP3vOeUqQhjPKI6t8B6OvMI/8JBUXyi0WyEcw9wqObeQ73opRzZOElY2T3sD0DO7JrOEn4+iM9LhkbZkxNwi0X3j2ASa+LSQakXqMlul+gYjaw3nvPrAV0CEyJ6KSFnI2GtxDaHiPHstL993hn4a5NfkXiwxc6bzli/grKcnb8neEGcXdjsPHzatCXD6Hrpac1+g/mGrfXVm5jwKIbtno38Rnumfn0tiHnufdSYj0G4mfRPfJFSo7m8JqM6YpzIyKWDMPfZURBpfEdECqxjgFx3HzTnwZ4Sc3Symy4Vdtc11l/JjcKqxG2M3U3e3DayzseniNFDmhPGst2plvc+Q9UsCKJrXUB0FjPl2RD8wg+0gZL2WNFRdvNkSlSJ6OBB2/846OcODZ1kWCC6NOnxFzKQJ9mDcbUuqtLvndB282SLA4c+QWh3XgEeGI2qIgPipwDfHF0BcOtPalZck8REp7khcskEhu6KpjK5YhMxbzRBUEYLdNmBAl0SdDppOUcZRFYy/2fPkAeuQzVbZgIfIqBFOflHVHn0q1pp7Hgy0DL1kMZ4ohUH3RgLdjrrKLnFTGeaQIhUjyrqvNM35UpMyoLFOM5MsQ2hsVThqiaV9ucThRBDFr1YDoR8i/z3T6Lv4lsafIm9NlRbcSO/PUD0k="


### PR DESCRIPTION
In order to collect more test summary information, we might want to use
a webhook, as opposed to relying on messages sent through slack. At the
very least, I want to know what information is exactly in the webhook
that we might be able to use.

The endpoint is encrypted, so it doesn't get flooded or anything.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/17431

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>