### PR TITLE
Increase timeouts while checking for running pods

### DIFF
--- a/test/policy-collection/policy_comp_operator_test.go
+++ b/test/policy-collection/policy_comp_operator_test.go
@@ -207,7 +207,7 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] Test compliance opera
 				podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{LabelSelector: "name=compliance-operator"})
 				Expect(err).To(BeNil())
 				return string(podList.Items[0].Status.Phase)
-			}, defaultTimeoutSeconds*2, 1).Should(Equal("Running"))
+			}, defaultTimeoutSeconds*4, 1).Should(Equal("Running"))
 		})
 		It("Profile bundle pods should be running", func() {
 			By("Checking if pod ocp4-pp has been created")

--- a/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
@@ -124,7 +124,7 @@ var _ = Describe("RHACM4K-3055", func() {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=audit-controller"})
 				Expect(err).To(BeNil())
 				return string(podList.Items[0].Status.Phase)
-			}, defaultTimeoutSeconds*2, 1).Should(Equal("Running"))
+			}, defaultTimeoutSeconds*4, 1).Should(Equal("Running"))
 		})
 
 		It("Gatekeeper controller manager pods should be running", func() {
@@ -139,7 +139,7 @@ var _ = Describe("RHACM4K-3055", func() {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=controller-manager"})
 				Expect(err).To(BeNil())
 				return string(podList.Items[0].Status.Phase) + "/" + string(podList.Items[1].Status.Phase)
-			}, defaultTimeoutSeconds*2, 1).Should(Equal("Running/Running"))
+			}, defaultTimeoutSeconds*4, 1).Should(Equal("Running/Running"))
 		})
 		It("stable/policy-gatekeeper-operator should be compliant", func() {
 			By("Checking if the status of root policy is compliant")

--- a/test/policy-collection/policy_gatekeeper_operator_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_test.go
@@ -171,7 +171,7 @@ var _ = Describe("", func() {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=audit-controller"})
 				Expect(err).To(BeNil())
 				return string(podList.Items[0].Status.Phase)
-			}, defaultTimeoutSeconds*2, 1).Should(Equal("Running"))
+			}, defaultTimeoutSeconds*4, 1).Should(Equal("Running"))
 		})
 
 		It("Gatekeeper controller manager pods should be running", func() {
@@ -186,7 +186,7 @@ var _ = Describe("", func() {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=controller-manager"})
 				Expect(err).To(BeNil())
 				return string(podList.Items[0].Status.Phase) + "/" + string(podList.Items[1].Status.Phase)
-			}, defaultTimeoutSeconds*2, 1).Should(Equal("Running/Running"))
+			}, defaultTimeoutSeconds*4, 1).Should(Equal("Running/Running"))
 		})
 		It("community/policy-gatekeeper-operator should be compliant", func() {
 			By("Checking if the status of root policy is compliant")


### PR DESCRIPTION
These were occasionally causing test failures when the cluster was just
a little bit slow. This increases the timeouts for these checks to a
consistent 120 seconds (these were only 60 before, but some others were
already 120).

Refs:
 - https://github.com/open-cluster-management/backlog/issues/18003

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>