### PR TITLE
Specify kubeconfig in dryrun patch

### DIFF
--- a/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
@@ -177,6 +177,7 @@ var _ = Describe("RHACM4K-3055", func() {
 				"patch", "-n", userNamespace, common.GvrPolicy.Resource+"."+common.GvrPlacementBinding.Group, GKPolicyName,
 				"--type=json", "-p=[{\"op\":\"remove\", \"path\": "+
 					"\"/spec/policy-templates/0/objectDefinition/spec/object-templates/1/objectDefinition/spec/enforcementAction\"}]",
+				"--kubeconfig="+kubeconfigHub,
 			)
 			By("Checking policy-gatekeeper namespace on hub cluster in ns " + userNamespace)
 			rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, GKPolicyName, userNamespace, true, defaultTimeoutSeconds)

--- a/test/policy-collection/policy_gatekeeper_operator_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_test.go
@@ -224,6 +224,7 @@ var _ = Describe("", func() {
 				"patch", "-n", userNamespace, common.GvrPolicy.Resource+"."+common.GvrPlacementBinding.Group, GKPolicyName,
 				"--type=json", "-p=[{\"op\":\"remove\", \"path\": "+
 					"\"/spec/policy-templates/0/objectDefinition/spec/object-templates/1/objectDefinition/spec/enforcementAction\"}]",
+				"--kubeconfig="+kubeconfigHub,
 			)
 			By("Checking policy-gatekeeper namespace on hub cluster in ns " + userNamespace)
 			rootPlc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, GKPolicyName, userNamespace, true, defaultTimeoutSeconds)


### PR DESCRIPTION
It worked locally, but it looks like this is needed in the test run.

Followup to:
- #217 

Signed-off-by: Dale Haiducek <dhaiduce@redhat.com>